### PR TITLE
Abmarl 166 move action wrapper

### DIFF
--- a/abmarl/sim/gridworld/actor.py
+++ b/abmarl/sim/gridworld/actor.py
@@ -112,46 +112,6 @@ class MoveActor(ActorBaseComponent):
                 return False
 
 
-# TODO: None of this is particular to a move actor. This is just particular to an
-# ActorBaseComponent. This would be different from an ObserverBaseComponent only
-# in that it uses the observation_space instead of the action_space. All that to
-# say, I think we can create a generic ravel action wrapper and a generic ravel
-# observer wrapper, which can then be used in the simulation construction.
-from abmarl.sim.wrappers.ravel_discrete_wrapper import ravel_space, unravel
-# TODO: Should the wrapper inherit the component it is wrapping?
-class DiscreteMoveActor(ActorBaseComponent): # TODO: Also a component wrapper
-    def __init__(self, wrapped_component, **kwargs):
-        super().__init__(**kwargs)
-        # TODO: Component wrapper parent
-        assert isinstance(wrapped_component, ActorBaseComponent), \
-            "Wrapped component must be an ActorBaseComponent."
-        self._wrapped_component = wrapped_component
-        for agent in self.agents.values():
-            if isinstance(agent, self.supported_agent_type):
-                unwrapped_space = agent.action_space[self.key]
-                wrapped_space = ravel_space(unwrapped_space)
-                agent.action_space[self.key] = wrapped_space
-
-    # TODO: Component wrapper parent
-    @property
-    def key(self):
-        return self._wrapped_component.key
-
-    # TODO: Component wrapper parent
-    @property
-    def supported_agent_type(self):
-        return self._wrapped_component.supported_agent_type
-
-    def process_action(self, agent, action_dict, **kwargs):
-        if isinstance(agent, self.supported_agent_type):
-            action = action_dict[self.key] # Action in the ravelled space
-            unwrapped_action = unravel(agent.action_space[self.key], action)
-            return self._wrapped_component.process_action(
-                agent,
-                {self.key: unwrapped_action}
-            )
-
-
 class AttackActor(ActorBaseComponent):
     """
     Agents can attack other agents.

--- a/abmarl/sim/gridworld/actor.py
+++ b/abmarl/sim/gridworld/actor.py
@@ -112,6 +112,11 @@ class MoveActor(ActorBaseComponent):
                 return False
 
 
+# TODO: None of this is particular to a move actor. This is just particular to an
+# ActorBaseComponent. This would be different from an ObserverBaseComponent only
+# in that it uses the observation_space instead of the action_space. All that to
+# say, I think we can create a generic ravel action wrapper and a generic ravel
+# observer wrapper, which can then be used in the simulation construction.
 from abmarl.sim.wrappers.ravel_discrete_wrapper import ravel_space, unravel
 # TODO: Should the wrapper inherit the component it is wrapping?
 class DiscreteMoveActor(ActorBaseComponent): # TODO: Also a component wrapper

--- a/abmarl/sim/gridworld/wrapper.py
+++ b/abmarl/sim/gridworld/wrapper.py
@@ -4,27 +4,30 @@ from abc import abstractmethod
 from abmarl.sim.gridworld.actor import ActorBaseComponent
 from abmarl.sim.gridworld.base import GridWorldBaseComponent
 
-# TODO: Should this be a GridWorldBaseComponent?
-# The ActorWrapper is already a GridWorldBaseComponent, so we are getting
-# the interface. This raises a bigger question about the design because the
-# Wrapper doesn't necessarily see the agents and the grid. It should just use
-# that from the component that it wraps. So we need a way to specify that the
-# wrapper does implement the api of the component, but that it doesn't receive
-# its own reference to the grid or the agent.
-# Instead of the super().__init__(), we can specify to only call the wrapper parent
-# chain instead of the component's init.
-class ComponentWrapper:
+class ComponentWrapper(GridWorldBaseComponent):
     """
     Wraps GridWorldBaseComponent.
 
     Every wrapper must be able to wrap and unwrap the respective space and points
-    to and from that space.
+    to and from that space. Agents and Grid are referenced directly from the wrapped
+    component rather than received as initialization parameters.
     """
     def __init__(self, component, **kwargs):
-        super().__init__(**kwargs)
         assert isinstance(component, GridWorldBaseComponent), \
             "Wrapped component must be a GridWorldBaseComponent."
         self._wrapped_component = component
+        # NOTE: Unlike every other class in our package, here we do not 
+        # call super().__init__. This is because we want to say that a wrapper
+        # implements the GridWorldBaseComponent interface but does not call
+        # its init. The same is true for child classes. For example, the Actor
+        # wrapper implements the ActorBaseComponent interface, but it should
+        # only call ComponentWrapper's init, not ActorBaseComponent's init. We
+        # don't expect this it interfere with the users' experience because this
+        # is just a design choice at the abstract level. Users who create component
+        # wrappers will singly-inherit from these abstract wrappers.
+        # TODO: Alternative Design is for the child classes to not call super at
+        # all since they can just set the wrapped object themselves. Make the
+        # wrapped_component property abstract.
 
     @property
     def wrapped_component(self):
@@ -42,6 +45,20 @@ class ComponentWrapper:
             return self.wrapped_component.unwrapped
         except AttributeError:
             return self.wrapped_component
+
+    @property
+    def agents(self):
+        """
+        The agent dictionary is directly taken from the wrapped component.
+        """
+        return self.wrapped_component.agents
+
+    @property
+    def grid(self):
+        """
+        The grid dictionary is directly taken from the wrapped component.
+        """
+        return self.wrapped_component.key
 
     @abstractmethod
     def check_space(self, space):
@@ -92,7 +109,8 @@ class ComponentWrapper:
         """
         pass
 
-class ActorWrapper(ActorBaseComponent, ComponentWrapper):
+# NOTE: This must have ComponentWrapper first for the MRO to work as we desire.
+class ActorWrapper(ComponentWrapper, ActorBaseComponent):
     """
     Wraps an ActorComponent.
 
@@ -101,10 +119,10 @@ class ActorWrapper(ActorBaseComponent, ComponentWrapper):
     We unwrap them and send them to the actor.
     """
     def __init__(self, component, **kwargs):
-        super().__init__(**kwargs)
+        super().__init__(component, **kwargs)
         assert isinstance(component, ActorBaseComponent), \
             "Wrapped component must be an ActorBaseComponent."
-        for agent in self.agents.values(): # TODO: Want self.agents for wrapper without explicitly giving it.
+        for agent in self.agents.values():
             if isinstance(agent, self.supported_agent_type):
                 assert self.check_space(agent.action_space[self.key]), \
                     f"Cannot wrap {self.key} action channel for agent {agent.id}"

--- a/abmarl/sim/gridworld/wrapper.py
+++ b/abmarl/sim/gridworld/wrapper.py
@@ -2,6 +2,7 @@
 from abc import abstractmethod
 
 from abmarl.sim.gridworld.actor import ActorBaseComponent
+from abmarl.sim.gridworld.observer import ObserverBaseComponent
 from abmarl.sim.gridworld.base import GridWorldBaseComponent
 
 class ComponentWrapper(GridWorldBaseComponent):
@@ -149,3 +150,10 @@ class ActorWrapper(ComponentWrapper, ActorBaseComponent):
                 {self.key: wrapped_action},
                 **kwargs
             )
+
+# TODO: Fill out the details of the observer wrapper.
+class ObserverWrapper(ComponentWrapper, ObserverBaseComponent):
+    pass
+
+
+

--- a/abmarl/sim/gridworld/wrapper.py
+++ b/abmarl/sim/gridworld/wrapper.py
@@ -1,0 +1,78 @@
+
+from abc import ABC, abstractmethod
+
+from abmarl.sim.gridworld.actor import ActorBaseComponent
+from abmarl.sim.gridworld.base import GridWorldBaseComponent
+
+class ComponentWrapper(ABC):
+    def __init__(self, component, **kwargs):
+        super().__init__(**kwargs)
+        assert isinstance(component, GridWorldBaseComponent), \
+            "Wrapped component must be a GridWorldBaseComponent."
+        self._wrapped_component = component
+
+    @property
+    def wrapped_component(self):
+        """
+        Get the first-level wrapped component.
+        """
+        return self._wrapped_component
+
+    @property
+    def unwrapped(self):
+        """
+        Fall through all the wrappers and obtain the original, completely unwrapped simulation.
+        """
+        try:
+            return self.wrapped_component.unwrapped
+        except AttributeError:
+            return self.wrapped_component
+
+    @abstractmethod
+    def check_space(self, space):
+        pass
+
+    @abstractmethod
+    def wrap_space(self, space):
+        pass
+
+    @abstractmethod
+    def unwrap_space(self, space):
+        pass
+
+    @abstractmethod
+    def wrap_point(self, space, point):
+        pass
+    
+    @abstractmethod
+    def unwrap_point(self, space, point):
+        pass
+
+class ActorWrapper(ActorBaseComponent, ComponentWrapper):
+    def __init__(self, component, **kwargs):
+        super().__init__(**kwargs)
+        assert isinstance(component, ActorBaseComponent), \
+            "Wrapped component must be an ActorBaseComponent."
+        for agent in self.agents.values():
+            if isinstance(agent, self.supported_agent_type):
+                assert self.check_space(agent.action_space[self.key]), \
+                    f"Cannot wrap {self.key} action channel for agent {agent.id}"
+                agent.action_space[self.key] = self.wrap_space(agent.action_space[self.key])
+
+    @property
+    def key(self):
+        return self._wrapped_component.key
+
+    @property
+    def supported_agent_type(self):
+        return self._wrapped_component.supported_agent_type
+
+    def process_action(self, agent, action_dict, **kwargs):
+        if isinstance(agent, self.supported_agent_type):
+            action = action_dict[self.key]
+            wrapped_action = self.wrap_point(agent.action_space[self.key], action)
+            return self.wrapped_component.process_action(
+                agent,
+                {self.key: wrapped_action},
+                **kwargs
+            )

--- a/abmarl/sim/gridworld/wrapper.py
+++ b/abmarl/sim/gridworld/wrapper.py
@@ -14,8 +14,8 @@ class ComponentWrapper(GridWorldBaseComponent):
     to and from that space. Agents and Grid are referenced directly from the wrapped
     component rather than received as initialization parameters.
     """
-    @abstractmethod
     @property
+    @abstractmethod
     def wrapped_component(self):
         """
         Get the first-level wrapped component.
@@ -153,6 +153,7 @@ class RavelActionWrapper(ActorWrapper):
         """
         return rdw.check_space(space)
 
+    # TODO: Input should be agent, not space.
     def wrap_space(self, space):
         """
         Convert the space into a Discrete space.

--- a/abmarl/sim/gridworld/wrapper.py
+++ b/abmarl/sim/gridworld/wrapper.py
@@ -1,10 +1,22 @@
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 
 from abmarl.sim.gridworld.actor import ActorBaseComponent
 from abmarl.sim.gridworld.base import GridWorldBaseComponent
 
-class ComponentWrapper(ABC):
+# TODO: Should this be a GridWorldBaseComponent?
+# The ActorWrapper is already a GridWorldBaseComponent, so we are getting
+# the interface. This raises a bigger question about the design because the
+# Wrapper doesn't necessarily see the agents and the grid. It should just use
+# that from the component that it wraps. So we need a way to specify that the
+# wrapper does implement the api of the component, but that it doesn't receive
+# its own reference to the grid or the agent.
+# Instead of the super().__init__(), we can specify to only call the wrapper parent
+# chain instead of the component's init.
+class ComponentWrapper:
+    """
+    Wraps GridWorldBaseComponent.
+    """
     def __init__(self, component, **kwargs):
         super().__init__(**kwargs)
         assert isinstance(component, GridWorldBaseComponent), \
@@ -30,22 +42,51 @@ class ComponentWrapper(ABC):
 
     @abstractmethod
     def check_space(self, space):
+        """
+        Verify that the space can be wrapped.
+        """
         pass
 
     @abstractmethod
     def wrap_space(self, space):
+        """
+        Wrap the space.
+
+        Args:
+            space: The space to wrap.
+        """
         pass
 
     @abstractmethod
     def unwrap_space(self, space):
+        """
+        Unwrap the space.
+
+        Args:
+            space: The space to unwrap.
+        """
         pass
 
     @abstractmethod
     def wrap_point(self, space, point):
+        """
+        Wrap a point to the space.
+
+        Args:
+            space: The space into which to wrap the point.
+            point: The point to wrap.
+        """
         pass
     
     @abstractmethod
     def unwrap_point(self, space, point):
+        """
+        Unwrap a point to the space.
+
+        Args:
+            space: The space into which to unwrap the point.
+            point: The point to unwrap.
+        """
         pass
 
 class ActorWrapper(ActorBaseComponent, ComponentWrapper):

--- a/abmarl/sim/gridworld/wrapper.py
+++ b/abmarl/sim/gridworld/wrapper.py
@@ -44,7 +44,7 @@ class ComponentWrapper(GridWorldBaseComponent):
         """
         The grid dictionary is directly taken from the wrapped component.
         """
-        return self.wrapped_component.key
+        return self.wrapped_component.grid
 
     @abstractmethod
     def check_space(self, space):

--- a/abmarl/sim/gridworld/wrapper.py
+++ b/abmarl/sim/gridworld/wrapper.py
@@ -98,9 +98,6 @@ class ActorWrapper(ComponentWrapper, ActorBaseComponent):
                 assert self.check_space(agent.action_space[self.key]), \
                     f"Cannot wrap {self.key} action channel for agent {agent.id}"
                 agent.action_space[self.key] = self.wrap_space(agent.action_space[self.key])
-        # TODO: Confirm that from_space is not just a reference to the space object
-        # but is a unique copy of it, otherwise it would have been transformed
-        # and is meaningless to have.
 
     @property
     def wrapped_component(self):
@@ -141,7 +138,7 @@ class ActorWrapper(ComponentWrapper, ActorBaseComponent):
                 **kwargs
             )
 
-# TODO: Fill out the details of the observer wrapper.
+# TODO: Fill out the details of the abstract observer wrapper.
 class ObserverWrapper(ComponentWrapper, ObserverBaseComponent):
     pass
 
@@ -153,7 +150,6 @@ class RavelActionWrapper(ActorWrapper):
         """
         return rdw.check_space(space)
 
-    # TODO: Input should be agent, not space.
     def wrap_space(self, space):
         """
         Convert the space into a Discrete space.

--- a/abmarl/sim/gridworld/wrapper.py
+++ b/abmarl/sim/gridworld/wrapper.py
@@ -114,14 +114,14 @@ class ActorWrapper(ComponentWrapper, ActorBaseComponent):
         """
         The key is the same as the wrapped actor's key.
         """
-        return self._wrapped_component.key
+        return self.wrapped_component.key
 
     @property
     def supported_agent_type(self):
         """
         The supported agent type is the same as the wrapped actor's supported agent type.
         """
-        return self._wrapped_component.supported_agent_type
+        return self.wrapped_component.supported_agent_type
 
     def process_action(self, agent, action_dict, **kwargs):
         """

--- a/abmarl/sim/gridworld/wrapper.py
+++ b/abmarl/sim/gridworld/wrapper.py
@@ -11,8 +11,8 @@ class ComponentWrapper(GridWorldBaseComponent):
     """
     Wraps GridWorldBaseComponent.
 
-    Every wrapper must be able to wrap and unwrap the respective space and points
-    to and from that space. Agents and Grid are referenced directly from the wrapped
+    Every wrapper must be able to wrap the respective space and points
+    to/from that space. Agents and Grid are referenced directly from the wrapped
     component rather than received as initialization parameters.
     """
     @property
@@ -43,7 +43,7 @@ class ComponentWrapper(GridWorldBaseComponent):
     @property
     def grid(self):
         """
-        The grid dictionary is directly taken from the wrapped component.
+        The grid is directly taken from the wrapped component.
         """
         return self.wrapped_component.grid
 
@@ -133,20 +133,23 @@ class ActorWrapper(ComponentWrapper, ActorBaseComponent):
         """
         if isinstance(agent, self.supported_agent_type):
             action = action_dict[self.key]
-            wrapped_action = self.wrap_point(self.from_space[agent.id], action)
+            unwrapped_action = self.wrap_point(self.from_space[agent.id], action)
             return self.wrapped_component.process_action(
                 agent,
-                {self.key: wrapped_action},
+                {self.key: unwrapped_action},
                 **kwargs
             )
 
 
-# TODO: Fill out the details of the abstract observer wrapper.
+# TODO Abmarl-202: Fill out the details of the abstract observer wrapper.
 class ObserverWrapper(ComponentWrapper, ObserverBaseComponent):
     pass
 
 
 class RavelActionWrapper(ActorWrapper):
+    """
+    Use numpy's ravel capabilities to convert space and points to Discrete.
+    """
     def check_space(self, space):
         """
         Ensure that the space is of type that can be ravelled to discrete value.
@@ -164,6 +167,7 @@ class RavelActionWrapper(ActorWrapper):
         Unravel a single discrete point to a value in the space.
 
         Recall that the action from the trainer arrives in the wrapped discrete
-        space, so we need to unravle it so that it is in the unwrapped space.
+        space, so we need to unravle it so that it is in the unwrapped space before
+        giving it to the actor.
         """
         return rdw.unravel(space, point)

--- a/abmarl/sim/gridworld/wrapper.py
+++ b/abmarl/sim/gridworld/wrapper.py
@@ -6,6 +6,7 @@ from abmarl.sim.gridworld.observer import ObserverBaseComponent
 from abmarl.sim.gridworld.base import GridWorldBaseComponent
 from abmarl.sim.wrappers import ravel_discrete_wrapper as rdw
 
+
 class ComponentWrapper(GridWorldBaseComponent):
     """
     Wraps GridWorldBaseComponent.
@@ -74,6 +75,7 @@ class ComponentWrapper(GridWorldBaseComponent):
         """
         pass
 
+
 class ActorWrapper(ComponentWrapper, ActorBaseComponent):
     """
     Wraps an ActorComponent.
@@ -138,6 +140,7 @@ class ActorWrapper(ComponentWrapper, ActorBaseComponent):
                 **kwargs
             )
 
+
 # TODO: Fill out the details of the abstract observer wrapper.
 class ObserverWrapper(ComponentWrapper, ObserverBaseComponent):
     pass
@@ -164,4 +167,3 @@ class RavelActionWrapper(ActorWrapper):
         space, so we need to unravle it so that it is in the unwrapped space.
         """
         return rdw.unravel(space, point)
-

--- a/tests/sim/gridworld/helpers.py
+++ b/tests/sim/gridworld/helpers.py
@@ -1,0 +1,22 @@
+
+import numpy as np
+
+from abmarl.sim.gridworld.grid import Grid
+from abmarl.sim.gridworld.actor import MovingAgent
+
+grid = Grid(5,6)
+
+moving_agents = {
+    'agent0': MovingAgent(
+        id='agent0', initial_position=np.array([3, 4]), encoding=1, move_range=1
+    ),
+    'agent1': MovingAgent(
+        id='agent1', initial_position=np.array([2, 2]), encoding=2, move_range=2
+    ),
+    'agent2': MovingAgent(
+        id='agent2', initial_position=np.array([0, 1]), encoding=1, move_range=1
+    ),
+    'agent3': MovingAgent(
+        id='agent3', initial_position=np.array([3, 1]), encoding=3, move_range=3
+    ),
+}

--- a/tests/sim/gridworld/test_actor.py
+++ b/tests/sim/gridworld/test_actor.py
@@ -8,11 +8,10 @@ from abmarl.sim.gridworld.state import PositionState, HealthState
 from abmarl.sim.gridworld.agent import MovingAgent, AttackingAgent, HealthAgent
 from abmarl.sim.gridworld.grid import Grid
 
-from .helpers import grid, moving_agents
+from .helpers import grid
 
 
 def test_move_actor():
-    grid = Grid(5, 6)
     agents = {
         'agent0': MovingAgent(
             id='agent0', initial_position=np.array([3, 4]), encoding=1, move_range=1
@@ -120,7 +119,6 @@ def test_move_actor_with_overlap():
 
 
 def test_attack_actor():
-    grid = Grid(5, 6)
     agents = {
         'agent0': HealthAgent(id='agent0', initial_position=np.array([4, 4]), encoding=1),
         'agent1': AttackingAgent(
@@ -161,7 +159,6 @@ def test_attack_actor():
 
 
 def test_attack_actor_attack_mapping():
-    grid = Grid(5, 6)
     agents = {
         'agent0': HealthAgent(id='agent0', initial_position=np.array([4, 4]), encoding=1),
         'agent1': AttackingAgent(

--- a/tests/sim/gridworld/test_actor.py
+++ b/tests/sim/gridworld/test_actor.py
@@ -8,6 +8,8 @@ from abmarl.sim.gridworld.state import PositionState, HealthState
 from abmarl.sim.gridworld.agent import MovingAgent, AttackingAgent, HealthAgent
 from abmarl.sim.gridworld.grid import Grid
 
+from .helpers import grid, moving_agents
+
 
 def test_move_actor():
     grid = Grid(5, 6)

--- a/tests/sim/gridworld/test_wrapper.py
+++ b/tests/sim/gridworld/test_wrapper.py
@@ -1,0 +1,67 @@
+
+from os import access
+from gym.spaces import Discrete, Box
+import numpy as np
+
+from abmarl.sim.gridworld.actor import MoveActor
+from abmarl.sim.gridworld.state import PositionState
+from abmarl.sim.gridworld.wrapper import RavelActionWrapper, ActorWrapper, ComponentWrapper
+from abmarl.sim.wrappers.ravel_discrete_wrapper import ravel
+
+from .helpers import grid, moving_agents as agents
+
+position_state = PositionState(grid=grid, agents=agents)
+move_actor = MoveActor(grid=grid, agents=agents)
+ravel_action_wrapper = RavelActionWrapper(move_actor)
+
+def test_ravel_action_wrapper_properties():
+    assert ravel_action_wrapper.wrapped_component == move_actor
+    assert ravel_action_wrapper.unwrapped == move_actor
+    assert ravel_action_wrapper.agents == move_actor.agents
+    assert ravel_action_wrapper.grid == move_actor.grid
+    assert ravel_action_wrapper.key == move_actor.key
+    assert ravel_action_wrapper.supported_agent_type == move_actor.supported_agent_type
+
+def test_ravel_action_wrapper_agent_spaces():
+    assert ravel_action_wrapper.from_space['agent0'] == Box(-1, 1, (2,), np.int)
+    assert ravel_action_wrapper.agents['agent0'].action_space['move'] == Discrete(9)
+    assert ravel_action_wrapper.from_space['agent1'] == Box(-2, 2, (2,), np.int)
+    assert ravel_action_wrapper.agents['agent1'].action_space['move'] == Discrete(25)
+    assert ravel_action_wrapper.from_space['agent2'] == Box(-1, 1, (2,), np.int)
+    assert ravel_action_wrapper.agents['agent2'].action_space['move'] == Discrete(9)
+    assert ravel_action_wrapper.from_space['agent3'] == Box(-3, 3, (2,), np.int)
+    assert ravel_action_wrapper.agents['agent3'].action_space['move'] == Discrete(49)
+
+def test_ravel_action_wrapper_process_action():
+    action_sample = {
+        'agent0': {'move': 7},
+        'agent1': {'move': 3},
+        'agent2': {'move': 4},
+        'agent3': {'move': 34},
+    }
+    np.testing.assert_array_equal(
+        ravel_action_wrapper.wrap_point(Box(-1, 1, (2,), np.int), 7),
+        np.array([1, 0])
+    )
+    np.testing.assert_array_equal(
+        ravel_action_wrapper.wrap_point(Box(-2, 2, (2,), np.int), 3),
+        np.array([-2, 1])
+    )
+    np.testing.assert_array_equal(
+        ravel_action_wrapper.wrap_point(Box(-1, 1, (2,), np.int), 4),
+        np.array([0, 0])
+    )
+    np.testing.assert_array_equal(
+        ravel_action_wrapper.wrap_point(Box(-3, 3, (2,), np.int), 34),
+        np.array([1, 3])
+    )
+
+    position_state.reset()
+    assert ravel_action_wrapper.process_action(agents['agent0'], action_sample['agent0'])
+    np.testing.assert_array_equal(agents['agent0'].position, np.array([4, 4]))
+    assert ravel_action_wrapper.process_action(agents['agent1'], action_sample['agent1'])
+    np.testing.assert_array_equal(agents['agent1'].position, np.array([0, 3]))
+    assert ravel_action_wrapper.process_action(agents['agent2'], action_sample['agent2'])
+    np.testing.assert_array_equal(agents['agent2'].position, np.array([0, 1]))
+    assert not ravel_action_wrapper.process_action(agents['agent3'], action_sample['agent3'])
+    np.testing.assert_array_equal(agents['agent3'].position, np.array([3, 1]))

--- a/tests/sim/gridworld/test_wrapper.py
+++ b/tests/sim/gridworld/test_wrapper.py
@@ -1,26 +1,29 @@
 
-from os import access
 from gym.spaces import Discrete, Box
 import numpy as np
 
-from abmarl.sim.gridworld.actor import MoveActor
+from abmarl.sim.gridworld.actor import MoveActor, ActorBaseComponent
 from abmarl.sim.gridworld.state import PositionState
-from abmarl.sim.gridworld.wrapper import RavelActionWrapper, ActorWrapper, ComponentWrapper
-from abmarl.sim.wrappers.ravel_discrete_wrapper import ravel
+from abmarl.sim.gridworld.wrapper import RavelActionWrapper, ActorWrapper
 
 from .helpers import grid, moving_agents as agents
+
 
 position_state = PositionState(grid=grid, agents=agents)
 move_actor = MoveActor(grid=grid, agents=agents)
 ravel_action_wrapper = RavelActionWrapper(move_actor)
 
+
 def test_ravel_action_wrapper_properties():
+    assert isinstance(ravel_action_wrapper, ActorWrapper)
+    assert isinstance(ravel_action_wrapper, ActorBaseComponent)
     assert ravel_action_wrapper.wrapped_component == move_actor
     assert ravel_action_wrapper.unwrapped == move_actor
     assert ravel_action_wrapper.agents == move_actor.agents
     assert ravel_action_wrapper.grid == move_actor.grid
     assert ravel_action_wrapper.key == move_actor.key
     assert ravel_action_wrapper.supported_agent_type == move_actor.supported_agent_type
+
 
 def test_ravel_action_wrapper_agent_spaces():
     assert ravel_action_wrapper.from_space['agent0'] == Box(-1, 1, (2,), np.int)
@@ -31,6 +34,7 @@ def test_ravel_action_wrapper_agent_spaces():
     assert ravel_action_wrapper.agents['agent2'].action_space['move'] == Discrete(9)
     assert ravel_action_wrapper.from_space['agent3'] == Box(-3, 3, (2,), np.int)
     assert ravel_action_wrapper.agents['agent3'].action_space['move'] == Discrete(49)
+
 
 def test_ravel_action_wrapper_process_action():
     action_sample = {


### PR DESCRIPTION
Beginnings of the component wrapper architecture for #227, specifically made the abstract actor wrapper architecture, which can be copied for the observer wrappers in #202. Created the ravel action wrapper and tested discretizing the move actor.

Resolves #166 