### PR TITLE
Abmarl 207 observe self arg

### DIFF
--- a/abmarl/sim/gridworld/observer.py
+++ b/abmarl/sim/gridworld/observer.py
@@ -98,7 +98,6 @@ class SingleGridObserver(ObserverBaseComponent):
         assert type(value) is bool, "Observe self must be a boolean."
         self._observe_self = value
 
-
     def get_obs(self, agent, **kwargs):
         """
         The agent observes a sub-grid centered on its position.

--- a/abmarl/sim/gridworld/observer.py
+++ b/abmarl/sim/gridworld/observer.py
@@ -60,8 +60,9 @@ class SingleGridObserver(ObserverBaseComponent):
     If there are multiple agents on a single cell with different encodings, the
     agent will observe only one of them chosen at random.
     """
-    def __init__(self, **kwargs):
+    def __init__(self, observe_self=True, **kwargs):
         super().__init__(**kwargs)
+        self.observe_self = observe_self
         max_encoding = max([agent.encoding for agent in self.agents.values()])
         for agent in self.agents.values():
             if isinstance(agent, self.supported_agent_type):
@@ -82,6 +83,21 @@ class SingleGridObserver(ObserverBaseComponent):
         This Observer works with GridObservingAgents.
         """
         return GridObservingAgent
+
+    @property
+    def observe_self(self):
+        """
+        Agents can observe themselves, which may hide important information if
+        overlapping is important. This can be turned off by setting observe_self
+        to False.
+        """
+        return self._observe_self
+
+    @observe_self.setter
+    def observe_self(self, value):
+        assert type(value) is bool, "Observe self must be a boolean."
+        self._observe_self = value
+
 
     def get_obs(self, agent, **kwargs):
         """
@@ -112,9 +128,20 @@ class SingleGridObserver(ObserverBaseComponent):
                     elif not candidate_agents: # In bounds empty cell
                         obs[r, c] = 0
                     else: # Observe one of the agents at this cell
-                        obs[r, c] = np.random.choice(
-                            [other.encoding for other in candidate_agents.values()]
-                        )
+                        if self.observe_self:
+                            obs[r, c] = np.random.choice([
+                                other.encoding for other in candidate_agents.values()
+                            ])
+                        else:
+                            choices = [
+                                other.encoding
+                                for other in candidate_agents.values()
+                                if other.id != agent.id
+                            ]
+                            # It may be that the observing agent is the only agent
+                            # at this location but it cannot observe itself, which
+                            # makes choices an empty list.
+                            obs[r, c] = np.random.choice(choices) if choices else 0
                 else: # Cell blocked by agent. Indicate invisible with -2
                     obs[r, c] = -2
 

--- a/tests/sim/gridworld/test_observer.py
+++ b/tests/sim/gridworld/test_observer.py
@@ -618,3 +618,62 @@ def test_multi_grid_observer_blocking():
             [-1, -1, -1, -1, -1, -1, -1, -1, -1]
         ])
     )
+
+def test_observe_self():
+    np.random.seed(24)
+    class HackAgent(GridObservingAgent, MovingAgent): pass
+
+    agents = {
+        'agent0': GridObservingAgent(
+            id='agent0', encoding=1, view_range=2, initial_position=np.array([2, 2])
+        ),
+        'agent1': GridObservingAgent(
+            id='agent1', encoding=2, view_range=1, initial_position=np.array([0, 0])
+        ),
+        'agent2': HackAgent(
+            id='agent2', encoding=2, view_range=1, initial_position=np.array([2, 2]), move_range=1
+        ),
+    }
+    grid = Grid(5, 5, overlapping={1: [2], 2: [1]})
+
+    position_state = PositionState(grid=grid, agents=agents)
+    position_state.reset()
+    self_observer = SingleGridObserver(agents=agents, grid=grid)
+    no_self_observer = SingleGridObserver(agents=agents, grid=grid, observe_self=False)
+
+    np.testing.assert_array_equal(
+        self_observer.get_obs(agents['agent0'])['grid'],
+        np.array([
+            [2, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 1, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0]
+        ])
+    )
+    np.testing.assert_array_equal(
+        no_self_observer.get_obs(agents['agent0'])['grid'],
+        np.array([
+            [2, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 2, 0, 0],
+            [0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0]
+        ])
+    )
+    np.testing.assert_array_equal(
+        self_observer.get_obs(agents['agent1'])['grid'],
+        np.array([
+            [-1, -1, -1],
+            [-1,  2,  0],
+            [-1,  0,  0]
+        ])
+    )
+    np.testing.assert_array_equal(
+        no_self_observer.get_obs(agents['agent1'])['grid'],
+        np.array([
+            [-1, -1, -1],
+            [-1,  0,  0],
+            [-1,  0,  0]
+        ])
+    )

--- a/tests/sim/gridworld/test_observer.py
+++ b/tests/sim/gridworld/test_observer.py
@@ -619,6 +619,7 @@ def test_multi_grid_observer_blocking():
         ])
     )
 
+
 def test_observe_self():
     np.random.seed(24)
     class HackAgent(GridObservingAgent, MovingAgent): pass


### PR DESCRIPTION
SingleGridObserver can be configured so that the observing agent does not observe itself, which is helpful when the grid supports overlapping and the agent needs to see if it is overlapping something.

Resolves #207 