### PR TITLE
Abmarl 266 upper bound gym and revert ravel discrete

### DIFF
--- a/abmarl/sim/wrappers/ravel_discrete_wrapper.py
+++ b/abmarl/sim/wrappers/ravel_discrete_wrapper.py
@@ -2,7 +2,6 @@ import itertools
 
 import numpy as np
 from gym.spaces import Discrete, MultiDiscrete, MultiBinary, Box, Dict, Tuple
-from gym.spaces.box import get_inf
 
 from .sar_wrapper import SARWrapper
 
@@ -118,10 +117,10 @@ def _isbounded(space):
     of that dtype. This function checks for min/max values of the dtype.
     """
     return space.is_bounded() and \
-        not (space.low == get_inf(int, '-')).any() and \
-        not (space.low == get_inf(int, '+')).any() and \
-        not (space.high == get_inf(int, '-')).any() and \
-        not (space.high == get_inf(int, '+')).any()
+        not (space.low == np.iinfo(space.dtype).min).any() and \
+        not (space.low == np.iinfo(space.dtype).max).any() and \
+        not (space.high == np.iinfo(space.dtype).min).any() and \
+        not (space.high == np.iinfo(space.dtype).max).any()
 
 
 def check_space(space):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 tensorflow
+gym<0.22
 ray[rllib]==1.4.0
 matplotlib
 seaborn

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     install_requires=[
         'tensorflow',
+        'gym<0.22',
         'ray[rllib]==1.4.0',
         'matplotlib',
         'seaborn',

--- a/tests/sim/test_agent_based_simulation.py
+++ b/tests/sim/test_agent_based_simulation.py
@@ -62,13 +62,13 @@ def test_acting_agent_action_space():
 
 def test_acting_agent_seed():
     from gym.spaces import Discrete
-    agent = ActingAgent(id='agent', seed=24, action_space={
+    agent = ActingAgent(id='agent', seed=17, action_space={
         1: Discrete(12),
         2: Discrete(3),
     })
     agent.finalize()
     assert agent.configured
-    assert agent.action_space.sample() == {1: 9, 2: 0}
+    assert agent.action_space.sample() == {1: 5, 2: 1}
 
 
 def test_observing_agent_observation_space():
@@ -98,7 +98,7 @@ def test_agent():
     agent.finalize()
     assert agent.configured
 
-    assert agent.action_space.sample() == {'act': 1}
+    assert agent.action_space.sample() == {'act': 2}
     assert agent.observation_space.sample() == {'obs': 0}
 
 


### PR DESCRIPTION
Reverted `get_inf` usage and pinned abmarl to gym<0.22 to reflect RLlib requirements.

Resolves #266 