### PR TITLE
Abmarl 264 update multiagent wrapper

### DIFF
--- a/abmarl/external/rllib_multiagentenv_wrapper.py
+++ b/abmarl/external/rllib_multiagentenv_wrapper.py
@@ -40,16 +40,3 @@ class MultiAgentWrapper(MultiAgentEnv):
     def render(self, *args, **kwargs):
         """See SimulationManager."""
         return self.sim.render(*args, **kwargs)
-
-    # @property
-    # def unwrapped(self):
-    #     """
-    #     Fall through all the wrappers to the SimulationManager.
-
-    #     Returns:
-    #         The wrapped SimulationManager.
-    #     """
-    #     try:
-    #         return self.sim.unwrapped
-    #     except AttributeError:
-    #         return self.sim

--- a/abmarl/external/rllib_multiagentenv_wrapper.py
+++ b/abmarl/external/rllib_multiagentenv_wrapper.py
@@ -41,15 +41,15 @@ class MultiAgentWrapper(MultiAgentEnv):
         """See SimulationManager."""
         return self.sim.render(*args, **kwargs)
 
-    @property
-    def unwrapped(self):
-        """
-        Fall through all the wrappers to the SimulationManager.
+    # @property
+    # def unwrapped(self):
+    #     """
+    #     Fall through all the wrappers to the SimulationManager.
 
-        Returns:
-            The wrapped SimulationManager.
-        """
-        try:
-            return self.sim.unwrapped
-        except AttributeError:
-            return self.sim
+    #     Returns:
+    #         The wrapped SimulationManager.
+    #     """
+    #     try:
+    #         return self.sim.unwrapped
+    #     except AttributeError:
+    #         return self.sim

--- a/abmarl/external/rllib_multiagentenv_wrapper.py
+++ b/abmarl/external/rllib_multiagentenv_wrapper.py
@@ -1,3 +1,5 @@
+
+from gym.spaces import Dict
 from ray.rllib import MultiAgentEnv
 
 
@@ -16,6 +18,16 @@ class MultiAgentWrapper(MultiAgentEnv):
         from abmarl.managers import SimulationManager
         assert isinstance(sim, SimulationManager)
         self.sim = sim
+
+        self._agent_ids = set(agent for agent in self.sim.agents)
+        self.observation_space = Dict({
+            agent.id: agent.observation_space
+            for agent in self.sim.agents.values()
+        })
+        self.action_space = Dict({
+            agent.id: agent.action_space
+            for agent in self.sim.agents.values()
+        })
 
     def reset(self):
         """See SimulationManager."""

--- a/abmarl/sim/corridor/multi_corridor.py
+++ b/abmarl/sim/corridor/multi_corridor.py
@@ -135,9 +135,9 @@ class MultiCorridor(AgentBasedSimulation):
         else:
             right = True
         return {
-            'position': [agent_position],
-            'left': [left],
-            'right': [right],
+            'position': np.array([agent_position]),
+            'left': np.array([int(left)]),
+            'right': np.array([int(right)]),
         }
 
     def get_done(self, agent_id, **kwargs):

--- a/examples/multi_corridor_example.py
+++ b/examples/multi_corridor_example.py
@@ -2,13 +2,13 @@ from abmarl.sim.corridor import MultiCorridor
 from abmarl.managers import TurnBasedManager
 from abmarl.external import MultiAgentWrapper
 
-sim = TurnBasedManager(MultiCorridor())
+sim = MultiAgentWrapper(TurnBasedManager(MultiCorridor()))
 
 sim_name = "MultiCorridor"
 from ray.tune.registry import register_env
-register_env(sim_name, lambda sim_config: MultiAgentWrapper(sim))
+register_env(sim_name, lambda sim_config: sim)
 
-ref_agent = sim.agents['agent0']
+ref_agent = sim.sim.agents['agent0']
 policies = {
     'corridor': (None, ref_agent.observation_space, ref_agent.action_space, {})
 }

--- a/examples/multi_corridor_example.py
+++ b/examples/multi_corridor_example.py
@@ -2,13 +2,13 @@ from abmarl.sim.corridor import MultiCorridor
 from abmarl.managers import TurnBasedManager
 from abmarl.external import MultiAgentWrapper
 
-sim = MultiAgentWrapper(TurnBasedManager(MultiCorridor()))
+sim = TurnBasedManager(MultiCorridor())
 
 sim_name = "MultiCorridor"
 from ray.tune.registry import register_env
-register_env(sim_name, lambda sim_config: sim)
+register_env(sim_name, lambda sim_config: MultiAgentWrapper(sim))
 
-ref_agent = sim.unwrapped.agents['agent0']
+ref_agent = sim.agents['agent0']
 policies = {
     'corridor': (None, ref_agent.observation_space, ref_agent.action_space, {})
 }
@@ -34,6 +34,7 @@ params = {
         'verbose': 2,
         'config': {
             # --- Simulation ---
+            'disable_env_checking': True,
             'env': sim_name,
             'horizon': 200,
             'env_config': {},

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 tensorflow
 gym<0.22
-ray[rllib]==1.9.0
+ray[rllib]
 matplotlib
 seaborn
 sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 tensorflow
 gym<0.22
-ray[rllib]
+ray[rllib]==1.12.1
 matplotlib
 seaborn
 sphinx

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     install_requires=[
         'tensorflow',
         'gym<0.22',
-        'ray[rllib]',
+        'ray[rllib]==1.12.1',
         'matplotlib',
         'seaborn',
     ],

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     install_requires=[
         'tensorflow',
         'gym<0.22',
-        'ray[rllib]==1.9.0',
+        'ray[rllib]',
         'matplotlib',
         'seaborn',
     ],


### PR DESCRIPTION
Updated the multiagentwrapper to support the new fields they expect, which are `_agent_ids`, `observation_space`, and `action_space`.

I had to modify the MultiCorridor game because the new version of RLlib is much stricter about the types it receives. This means that the GSF probably won't connect with RLlib since I'm not strict with the output there either. In #271 I will modify the wrapper even more to bridge the strict outputs with the easy-to-design outputs.

Resolves #264
Resolves #270 