### PR TITLE
Abmarl 271 rllib stricter outputs

### DIFF
--- a/abmarl/external/rllib_multiagentenv_wrapper.py
+++ b/abmarl/external/rllib_multiagentenv_wrapper.py
@@ -21,7 +21,10 @@ class MultiAgentWrapper(MultiAgentEnv):
         assert isinstance(sim, SimulationManager)
         self.sim = sim
 
-        self._agent_ids = set(agent for agent in self.sim.agents)
+        self._agent_ids = set(
+            agent.id for agent in self.sim.agents.values()
+            if isinstance(agent, ActingAgent) and isinstance(agent, ObservingAgent)
+        )
         self.observation_space = Dict({
             agent.id: agent.observation_space
             for agent in self.sim.agents.values()

--- a/abmarl/external/rllib_multiagentenv_wrapper.py
+++ b/abmarl/external/rllib_multiagentenv_wrapper.py
@@ -2,6 +2,8 @@
 from gym.spaces import Dict
 from ray.rllib import MultiAgentEnv
 
+from abmarl.sim.agent_based_simulation import ActingAgent, ObservingAgent
+
 
 class MultiAgentWrapper(MultiAgentEnv):
     """
@@ -23,10 +25,12 @@ class MultiAgentWrapper(MultiAgentEnv):
         self.observation_space = Dict({
             agent.id: agent.observation_space
             for agent in self.sim.agents.values()
+            if isinstance(agent, ObservingAgent)
         })
         self.action_space = Dict({
             agent.id: agent.action_space
             for agent in self.sim.agents.values()
+            if isinstance(agent, ActingAgent)
         })
 
     def reset(self):

--- a/abmarl/sim/gridworld/examples/team_battle_example.py
+++ b/abmarl/sim/gridworld/examples/team_battle_example.py
@@ -43,8 +43,8 @@ class TeamBattleSim(GridWorldSimulation):
         self.finalize()
 
     def reset(self, **kwargs):
-        self.position_state.reset(**kwargs)
         self.health_state.reset(**kwargs)
+        self.position_state.reset(**kwargs)
 
         # Track the rewards
         self.rewards = {agent.id: 0 for agent in self.agents.values()}

--- a/examples/maze.txt
+++ b/examples/maze.txt
@@ -1,0 +1,8 @@
+0 0 0 0 W 0 W W 0 W W 0 0 W W 0 W 0
+W 0 W 0 N 0 0 0 0 0 W 0 W W 0 0 0 0
+W W W W 0 W W 0 W 0 0 0 0 W W 0 W W
+0 W 0 0 0 W W 0 W 0 W W 0 0 0 0 0 0
+0 0 0 W 0 0 W W W 0 W 0 0 W 0 W W 0
+W W W W 0 W W W W W W W 0 W 0 T W 0
+0 0 0 0 0 W 0 0 0 0 0 0 0 W 0 W W 0
+0 W 0 W 0 W W W 0 W W 0 W W 0 W 0 0

--- a/examples/maze_navigation_example.py
+++ b/examples/maze_navigation_example.py
@@ -1,0 +1,94 @@
+
+import numpy as np
+
+from abmarl.sim.gridworld.examples.maze_navigation import MazeNavigationAgent, MazeNaviationSim
+from abmarl.sim.gridworld.agent import GridWorldAgent
+from abmarl.managers import AllStepManager
+from abmarl.external import MultiAgentWrapper
+
+object_registry = {
+    'N': lambda n: MazeNavigationAgent(
+        id='navigator',
+        encoding=1,
+        view_range=2,
+        render_color='blue',
+    ),
+    'T': lambda n: GridWorldAgent(
+        id='target',
+        encoding=3,
+        render_color='green'
+    ),
+    'W': lambda n: GridWorldAgent(
+        id=f'wall{n}',
+        encoding=2,
+        blocking=True,
+        render_shape='s'
+    )
+}
+
+file_name = 'maze.txt'
+sim = MultiAgentWrapper(
+    AllStepManager(
+        MazeNaviationSim.build_sim_from_file(
+            file_name,
+            object_registry,
+            overlapping={1: [3], 3: [1]}
+        )
+    )
+)
+
+
+sim_name = "MazeNavigation"
+from ray.tune.registry import register_env
+register_env(sim_name, lambda sim_config: sim)
+
+
+
+policies = {
+    'navigator': (
+        None,
+        sim.sim.agents['navigator'].observation_space,
+        sim.sim.agents['navigator'].action_space,
+        {}
+    )
+}
+
+
+def policy_mapping_fn(agent_id):
+    return 'navigator'
+
+
+# Experiment parameters
+params = {
+    'experiment': {
+        'title': f'{sim_name}',
+        'sim_creator': lambda config=None: sim,
+    },
+    'ray_tune': {
+        'run_or_experiment': 'A2C',
+        'checkpoint_freq': 50,
+        'checkpoint_at_end': True,
+        'stop': {
+            'episodes_total': 2000,
+        },
+        'verbose': 2,
+        'config': {
+            # --- Simulation ---
+            'disable_env_checking': False,
+            'env': sim_name,
+            'horizon': 200,
+            'env_config': {},
+            # --- Multiagent ---
+            'multiagent': {
+                'policies': policies,
+                'policy_mapping_fn': policy_mapping_fn,
+            },
+            # "lr": 0.0001,
+            # --- Parallelism ---
+            # Number of workers per experiment: int
+            "num_workers": 7,
+            # Number of simulations that each worker starts: int
+            "num_envs_per_worker": 1, # This must be 1 because we are not "threadsafe"
+        },
+    }
+}

--- a/examples/team_battle_example.py
+++ b/examples/team_battle_example.py
@@ -55,13 +55,13 @@ policies = {
 
 
 def policy_mapping_fn(agent_id):
-    if agent_id.startswith('red'):
+    if agents[agent_id].encoding == 1:
         return 'red'
-    if agent_id.startswith('green'):
-        return 'green'
-    if agent_id.startswith('blue'):
+    if agents[agent_id].encoding == 2:
         return 'blue'
-    if agent_id.startswith('gray'):
+    if agents[agent_id].encoding == 3:
+        return 'green'
+    if agents[agent_id].encoding == 4:
         return 'gray'
 
 

--- a/examples/team_battle_example.py
+++ b/examples/team_battle_example.py
@@ -1,0 +1,101 @@
+
+import numpy as np
+
+from abmarl.sim.gridworld.examples.team_battle_example import BattleAgent, TeamBattleSim
+from abmarl.managers import AllStepManager
+from abmarl.external import MultiAgentWrapper
+
+
+colors = ['red', 'blue', 'green', 'gray']
+positions = [np.array([1, 1]), np.array([1, 6]), np.array([6, 1]), np.array([6, 6])]
+agents = {
+    f'agent{i}': BattleAgent(
+        id=f'agent{i}',
+        encoding=i % 4 + 1,
+        render_color=colors[i % 4],
+        initial_position=positions[i % 4]
+    ) for i in range(24)
+}
+overlap_map = {
+    1: [1],
+    2: [2],
+    3: [3],
+    4: [4]
+}
+attack_map = {
+    1: [2, 3, 4],
+    2: [1, 3, 4],
+    3: [1, 2, 4],
+    4: [1, 2, 3]
+}
+sim = MultiAgentWrapper(
+    AllStepManager(
+        TeamBattleSim.build_sim(
+            8, 8,
+            agents=agents,
+            overlapping=overlap_map,
+            attack_mapping=attack_map
+        )
+    )
+)
+
+
+sim_name = "TeamBattle"
+from ray.tune.registry import register_env
+register_env(sim_name, lambda sim_config: sim)
+
+
+ref_agent = sim.sim.agents['agent0']
+policies = {
+    'red': (None, agents['agent0'].observation_space, agents['agent0'].action_space, {}),
+    'blue': (None, agents['agent1'].observation_space, agents['agent1'].action_space, {}),
+    'green': (None, agents['agent2'].observation_space, agents['agent2'].action_space, {}),
+    'gray': (None, agents['agent3'].observation_space, agents['agent3'].action_space, {}),
+}
+
+
+def policy_mapping_fn(agent_id):
+    if agent_id.startswith('red'):
+        return 'red'
+    if agent_id.startswith('green'):
+        return 'green'
+    if agent_id.startswith('blue'):
+        return 'blue'
+    if agent_id.startswith('gray'):
+        return 'gray'
+
+
+# Experiment parameters
+params = {
+    'experiment': {
+        'title': f'{sim_name}',
+        'sim_creator': lambda config=None: sim,
+    },
+    'ray_tune': {
+        'run_or_experiment': 'A2C',
+        'checkpoint_freq': 50,
+        'checkpoint_at_end': True,
+        'stop': {
+            'episodes_total': 2000,
+        },
+        'verbose': 2,
+        'config': {
+            # --- Simulation ---
+            'disable_env_checking': False,
+            'env': sim_name,
+            'horizon': 200,
+            'env_config': {},
+            # --- Multiagent ---
+            'multiagent': {
+                'policies': policies,
+                'policy_mapping_fn': policy_mapping_fn,
+            },
+            # "lr": 0.0001,
+            # --- Parallelism ---
+            # Number of workers per experiment: int
+            "num_workers": 0,
+            # Number of simulations that each worker starts: int
+            "num_envs_per_worker": 1, # This must be 1 because we are not "threadsafe"
+        },
+    }
+}

--- a/examples/team_battle_example.py
+++ b/examples/team_battle_example.py
@@ -45,7 +45,6 @@ from ray.tune.registry import register_env
 register_env(sim_name, lambda sim_config: sim)
 
 
-ref_agent = sim.sim.agents['agent0']
 policies = {
     'red': (None, agents['agent0'].observation_space, agents['agent0'].action_space, {}),
     'blue': (None, agents['agent1'].observation_space, agents['agent1'].action_space, {}),
@@ -93,7 +92,7 @@ params = {
             # "lr": 0.0001,
             # --- Parallelism ---
             # Number of workers per experiment: int
-            "num_workers": 0,
+            "num_workers": 7,
             # Number of simulations that each worker starts: int
             "num_envs_per_worker": 1, # This must be 1 because we are not "threadsafe"
         },


### PR DESCRIPTION
I enhanced the MultiAgentWrapper to only use Agents, not all entities.
I created an example of training the team battle game.
I created an example of training the maze navigation game.

These games connected with RLlib immediately, so there doesn't appear to be an issue with the spaces contained in the GSF. The main problem that I found with the MutliCorridor game is with the TurnBasedWrapper. I've already added a note to #277 for this.

Resolves #271