### PR TITLE
Agent meta to fix isinstance attempt

### DIFF
--- a/abmarl/sim/agent_based_simulation.py
+++ b/abmarl/sim/agent_based_simulation.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from collections.abc import Container
-from typing import Any
 
 from abmarl.tools import gym_utils as gu
 
@@ -136,12 +135,14 @@ class ObservingAgent(PrincipleAgent):
             self.observation_space = gu.make_dict(self.observation_space)
         self.observation_space.seed(self.seed)
 
+
 class AgentMeta(type):
     """
     AgentMeta class defines an Agent as an instance of ObservingAgent and ActingAgent.
     """
     def __instancecheck__(self, instance):
         return isinstance(instance, ObservingAgent) and isinstance(instance, ActingAgent)
+
 
 class Agent(ObservingAgent, ActingAgent, metaclass=AgentMeta):
     """

--- a/abmarl/sim/agent_based_simulation.py
+++ b/abmarl/sim/agent_based_simulation.py
@@ -136,13 +136,18 @@ class ObservingAgent(PrincipleAgent):
             self.observation_space = gu.make_dict(self.observation_space)
         self.observation_space.seed(self.seed)
 
+class AgentMeta(type):
+    """
+    AgentMeta class defines an Agent as an instance of ObservingAgent and ActingAgent.
+    """
+    def __instancecheck__(self, instance):
+        return isinstance(instance, ObservingAgent) and isinstance(instance, ActingAgent)
 
-class Agent(ObservingAgent, ActingAgent):
+class Agent(ObservingAgent, ActingAgent, metaclass=AgentMeta):
     """
     An Agent that can both observe and act.
     """
-    def __instancecheck__(self, __instance: Any) -> bool:
-        return isinstance(__instance, ObservingAgent) and isinstance(__instance, ActingAgent)
+    pass
 
 
 class AgentBasedSimulation(ABC):

--- a/tests/sim/test_agent_based_simulation.py
+++ b/tests/sim/test_agent_based_simulation.py
@@ -103,6 +103,16 @@ def test_agent():
     assert agent.observation_space.sample() == {'obs': 0}
 
 
+def test_agent_instance():
+    class TestAgent(ObservingAgent, ActingAgent): pass
+    agent_1 = TestAgent(id='agent1')
+    agent_2 = Agent(id='agent2')
+    assert isinstance(agent_1, ObservingAgent)
+    assert isinstance(agent_1, ActingAgent)
+    assert isinstance(agent_1, Agent)
+    assert isinstance(agent_2, Agent)
+
+
 def test_agent_based_simulation_agents():
     class ABS(AgentBasedSimulation):
         def __init__(self, agents):


### PR DESCRIPTION
Resolves #286 

@mojoee The instance check needed to be put on the meta class. I did not know this and I assumed the test suite would have caught the difference, but it did not.