### PR TITLE
Abmarl 256 components define null point in space

### DIFF
--- a/abmarl/sim/agent_based_simulation.py
+++ b/abmarl/sim/agent_based_simulation.py
@@ -89,8 +89,6 @@ class ActingAgent(PrincipleAgent):
 
     @null_action.setter
     def null_action(self, value):
-        assert value is None or gu.check_point_in_space(value, self.action_space), \
-            "The null action must be a point in the action space."
         self._null_action = {} if value is None else value
 
     @property
@@ -109,6 +107,9 @@ class ActingAgent(PrincipleAgent):
         if type(self.action_space) is dict:
             self.action_space = gu.make_dict(self.action_space)
         self.action_space.seed(self.seed)
+        if self.null_action:
+            assert self.null_action in self.action_space, \
+                "The null action must be in the action space."
 
 
 class ObservingAgent(PrincipleAgent):
@@ -142,8 +143,6 @@ class ObservingAgent(PrincipleAgent):
 
     @null_observation.setter
     def null_observation(self, value):
-        assert value is None or gu.check_point_in_space(value, self.observation_space), \
-            "The null observation must be a point in the action space."
         self._null_observation = {} if value is None else value
 
     @property
@@ -162,6 +161,9 @@ class ObservingAgent(PrincipleAgent):
         if type(self.observation_space) is dict:
             self.observation_space = gu.make_dict(self.observation_space)
         self.observation_space.seed(self.seed)
+        if self.null_observation:
+            assert self.null_observation in self.observation_space, \
+                "The null observation must be in the observation space."
 
 
 class AgentMeta(type):

--- a/abmarl/sim/agent_based_simulation.py
+++ b/abmarl/sim/agent_based_simulation.py
@@ -65,9 +65,10 @@ class ActingAgent(PrincipleAgent):
     The Trainer will produce actions for the agents and send them to the SimulationManager,
     which will process those actions in its step function.
     """
-    def __init__(self, action_space=None, **kwargs):
+    def __init__(self, action_space=None, null_action=None, **kwargs):
         super().__init__(**kwargs)
         self.action_space = action_space
+        self.null_action = null_action
 
     @property
     def action_space(self):
@@ -78,6 +79,19 @@ class ActingAgent(PrincipleAgent):
         assert value is None or gu.check_space(value), \
             "The action space must be None, a gym Space, or a dict of gym Spaces."
         self._action_space = {} if value is None else value
+
+    @property
+    def null_action(self):
+        """
+        The null point in the action space.
+        """
+        return self._null_action
+
+    @null_action.setter
+    def null_action(self, value):
+        assert value is None or gu.check_point_in_space(value, self.action_space), \
+            "The null action must be a point in the action space."
+        self._null_action = {} if value is None else value
 
     @property
     def configured(self):
@@ -104,9 +118,10 @@ class ObservingAgent(PrincipleAgent):
     The agent's observation must be *in* its observation space. The SimulationManager
     will send the observation to the Trainer, which will use it to produce actions.
     """
-    def __init__(self, observation_space=None, **kwargs):
+    def __init__(self, observation_space=None, null_observation=None, **kwargs):
         super().__init__(**kwargs)
         self.observation_space = observation_space
+        self.null_observation = null_observation
 
     @property
     def observation_space(self):
@@ -117,6 +132,19 @@ class ObservingAgent(PrincipleAgent):
         assert value is None or gu.check_space(value), \
             "The observation space must be None, a gym Space, or a dict of gym Spaces."
         self._observation_space = {} if value is None else value
+
+    @property
+    def null_observation(self):
+        """
+        The null point in the observation space.
+        """
+        return self._null_observation
+
+    @null_observation.setter
+    def null_observation(self, value):
+        assert value is None or gu.check_point_in_space(value, self.observation_space), \
+            "The null observation must be a point in the action space."
+        self._null_observation = {} if value is None else value
 
     @property
     def configured(self):

--- a/abmarl/sim/gridworld/actor.py
+++ b/abmarl/sim/gridworld/actor.py
@@ -62,6 +62,7 @@ class MoveActor(ActorBaseComponent):
                 agent.action_space[self.key] = Box(
                     -agent.move_range, agent.move_range, (2,), int
                 )
+                agent.null_action[self.key] = np.zeros((2,), dtype=int)
 
     @property
     def key(self):
@@ -122,6 +123,7 @@ class AttackActor(ActorBaseComponent):
         for agent in self.agents.values():
             if isinstance(agent, self.supported_agent_type):
                 agent.action_space[self.key] = Discrete(2)
+                agent.null_action[self.key] = 0
 
     @property
     def attack_mapping(self):

--- a/abmarl/sim/gridworld/observer.py
+++ b/abmarl/sim/gridworld/observer.py
@@ -69,6 +69,10 @@ class SingleGridObserver(ObserverBaseComponent):
                 agent.observation_space[self.key] = Box(
                     -2, max_encoding, (agent.view_range * 2 + 1, agent.view_range * 2 + 1), int
                 )
+                agent.null_observation[self.key] = -2 * np.ones(
+                    (agent.view_range * 2 + 1, agent.view_range * 2 + 1),
+                    dtype=int
+                )
 
     @property
     def key(self):
@@ -166,6 +170,10 @@ class MultiGridObserver(ObserverBaseComponent):
                     len(self.agents),
                     (agent.view_range * 2 + 1, agent.view_range * 2 + 1, self.number_of_encodings),
                     int
+                )
+                agent.null_observation[self.key] = -2 * np.ones(
+                    (agent.view_range * 2 + 1, agent.view_range * 2 + 1, self.number_of_encodings),
+                    dtype=int
                 )
 
     @property

--- a/abmarl/sim/wrappers/super_agent_wrapper.py
+++ b/abmarl/sim/wrappers/super_agent_wrapper.py
@@ -24,7 +24,7 @@ class SuperAgentWrapper(Wrapper):
     covered agents. This may contaminate the training data with an unfair advantage.
     For exmample, a dead covered agent should not be able to provide the super agent with
     useful information. In order to correct this, the user may supply the null
-    observation on an ObservingAgent, like so:
+    observation for an ObservingAgent, like so:
         agent = ObservingAgent(
             id="agent",
             observation_space=Discrete(3),

--- a/examples/team_battle_super_agent.py
+++ b/examples/team_battle_super_agent.py
@@ -15,7 +15,6 @@ agents = {
         encoding=i % 4 + 1,
         render_color=colors[i % 4],
         initial_position=positions[i % 4],
-        null_observation={'grid': -2 * np.ones((7, 7), dtype=int)}
     ) for i in range(24)
 }
 overlap_map = {

--- a/tests/sim/gridworld/test_actor.py
+++ b/tests/sim/gridworld/test_actor.py
@@ -147,7 +147,6 @@ def test_attack_actor():
     assert agents['agent1'].action_space['attack'] == Discrete(2)
 
     agents['agent1'].finalize()
-    assert agents['agent1'].null_action.keys() == set(('attack',))
     assert agents['agent1'].null_action == {'attack': 0}
 
     position_state.reset()

--- a/tests/sim/gridworld/test_actor.py
+++ b/tests/sim/gridworld/test_actor.py
@@ -37,6 +37,11 @@ def test_move_actor():
     assert agents['agent2'].action_space['move'] == Box(-1, 1, (2,), int)
     assert agents['agent3'].action_space['move'] == Box(-3, 3, (2,), int)
 
+    for agent in agents.values():
+        agent.finalize()
+        assert agent.null_action.keys() == set(('move',))
+        np.testing.assert_array_equal(agent.null_action['move'], np.zeros((2,), dtype=int))
+
     position_state.reset()
     action = {
         'agent0': {'move': np.array([1, 1])},
@@ -140,6 +145,10 @@ def test_attack_actor():
     assert attack_actor.key == 'attack'
     assert attack_actor.supported_agent_type == AttackingAgent
     assert agents['agent1'].action_space['attack'] == Discrete(2)
+
+    agents['agent1'].finalize()
+    assert agents['agent1'].null_action.keys() == set(('attack',))
+    assert agents['agent1'].null_action == {'attack': 0}
 
     position_state.reset()
     health_state.reset()

--- a/tests/sim/gridworld/test_observer.py
+++ b/tests/sim/gridworld/test_observer.py
@@ -41,6 +41,22 @@ def test_single_grid_observer():
         -2, 6, (9, 9), int
     )
 
+    agents['agent0'].finalize()
+    assert agents['agent0'].null_observation.keys() == set(('grid',))
+    np.testing.assert_array_equal(
+        agents['agent0'].null_observation['grid'], -2 * np.ones((5, 5), dtype=int)
+    )
+    agents['agent1'].finalize()
+    assert agents['agent1'].null_observation.keys() == set(('grid',))
+    np.testing.assert_array_equal(
+        agents['agent1'].null_observation['grid'], -2 * np.ones((3, 3), dtype=int)
+    )
+    agents['agent2'].finalize()
+    assert agents['agent2'].null_observation.keys() == set(('grid',))
+    np.testing.assert_array_equal(
+        agents['agent2'].null_observation['grid'], -2 * np.ones((9, 9), dtype=int)
+    )
+
     position_state.reset()
     np.testing.assert_array_equal(
         observer.get_obs(agents['agent0'])['grid'],
@@ -187,6 +203,23 @@ def test_multi_grid_observer():
     assert agents['agent2'].observation_space['grid'] == Box(
         -2, 9, (9, 9, 6), int
     )
+
+    agents['agent0'].finalize()
+    assert agents['agent0'].null_observation.keys() == set(('grid',))
+    np.testing.assert_array_equal(
+        agents['agent0'].null_observation['grid'], -2 * np.ones((5, 5, 6), dtype=int)
+    )
+    agents['agent1'].finalize()
+    assert agents['agent1'].null_observation.keys() == set(('grid',))
+    np.testing.assert_array_equal(
+        agents['agent1'].null_observation['grid'], -2 * np.ones((3, 3, 6), dtype=int)
+    )
+    agents['agent2'].finalize()
+    assert agents['agent2'].null_observation.keys() == set(('grid',))
+    np.testing.assert_array_equal(
+        agents['agent2'].null_observation['grid'], -2 * np.ones((9, 9, 6), dtype=int)
+    )
+
     position_state.reset()
 
     np.testing.assert_array_equal(

--- a/tests/sim/test_agent_based_simulation.py
+++ b/tests/sim/test_agent_based_simulation.py
@@ -61,6 +61,18 @@ def test_acting_agent_action_space():
     assert agent.configured
 
 
+def test_acting_agent_null_action():
+    from gym.spaces import MultiBinary
+    agent1 = ActingAgent(id='agent1', action_space=MultiBinary(4), null_action=[0, 0, 0, 0])
+    agent1.finalize()
+
+    # This will not raise an assertion error because the test happens at finalize
+    agent2 = ActingAgent(id='agent2', action_space=MultiBinary(4), null_action=[0, 0, 0])
+
+    with pytest.raises(AssertionError):
+        agent2.finalize()
+
+
 def test_acting_agent_seed():
     from gym.spaces import Discrete
     agent = ActingAgent(id='agent', seed=17, action_space={
@@ -87,6 +99,22 @@ def test_observing_agent_observation_space():
     assert not agent.configured
     agent.finalize()
     assert agent.configured
+
+
+def test_observing_agent_null_observation():
+    from gym.spaces import MultiBinary
+    agent1 = ObservingAgent(
+        id='agent1', observation_space=MultiBinary(4), null_observation=[0, 0, 0, 0]
+    )
+    agent1.finalize()
+
+    # This will not raise an assertion error because the test happens at finalize
+    agent2 = ObservingAgent(
+        id='agent2', observation_space=MultiBinary(4), null_observation=[0, 0, 0]
+    )
+
+    with pytest.raises(AssertionError):
+        agent2.finalize()
 
 
 def test_agent():

--- a/tests/sim/wrappers/test_super_agent_wrapper.py
+++ b/tests/sim/wrappers/test_super_agent_wrapper.py
@@ -175,19 +175,6 @@ def test_agent_spaces():
     assert agents['agent2'] == original_agents['agent2']
     assert agents['agent4'] == original_agents['agent4']
 
-# TODO: Use these tests in the null obs and null_action test in test_abs.py
-# def test_null_obs():
-#     assert sim.null_obs == {'agent0': [0, 0, 0, 0]}
-
-
-# def test_null_obs_breaks():
-#     with pytest.raises(AssertionError):
-#         sim.null_obs = [0, 1]
-#     with pytest.raises(AssertionError):
-#         sim.null_obs = {'agent0': [0, 0, 0, 0], 'agent1': [0]}
-#     with pytest.raises(AssertionError):
-#         sim.null_obs = {'agent0': [0, 0, 0, 0, 0]}
-
 
 def test_sim_step():
     sim.reset()


### PR DESCRIPTION
Resolves #256

The `SuperAgentWrapper` does not take `null_obs` as an argument. The `null_observation` is attached to the `ObservingAgent`, and the `SuperAgentWrapper` looks for it on the agent itself. This is more in line with the overall data-class design I have done for agents.

I have added a `null_action` as well.

The built-in components in the GSF automatically populate the `null_obs` and `null_action` in the respective agents. So now the super agent team battle example doesn't need to specify anything for the null obs since the BattleAgent gets it from the components.