### PR TITLE
Abmarl 363 full grid observer

### DIFF
--- a/abmarl/examples/sim/maze_navigation.py
+++ b/abmarl/examples/sim/maze_navigation.py
@@ -6,7 +6,6 @@ from abmarl.sim.gridworld.agent import GridObservingAgent, MovingAgent
 from abmarl.sim.gridworld.state import PositionState
 from abmarl.sim.gridworld.actor import MoveActor
 from abmarl.sim.gridworld.observer import SingleGridObserver
-from abmarl.sim.gridworld.observer import AbsoluteGridObserver
 
 
 class MazeNavigationAgent(GridObservingAgent, MovingAgent):
@@ -27,7 +26,7 @@ class MazeNaviationSim(GridWorldSimulation):
         self.move_actor = MoveActor(**kwargs)
 
         # Observation Components
-        self.grid_observer = AbsoluteGridObserver(**kwargs)
+        self.grid_observer = SingleGridObserver(**kwargs)
 
         self.finalize()
 

--- a/abmarl/examples/sim/maze_navigation.py
+++ b/abmarl/examples/sim/maze_navigation.py
@@ -6,6 +6,7 @@ from abmarl.sim.gridworld.agent import GridObservingAgent, MovingAgent
 from abmarl.sim.gridworld.state import PositionState
 from abmarl.sim.gridworld.actor import MoveActor
 from abmarl.sim.gridworld.observer import SingleGridObserver
+from abmarl.sim.gridworld.observer import AbsoluteGridObserver
 
 
 class MazeNavigationAgent(GridObservingAgent, MovingAgent):
@@ -26,7 +27,7 @@ class MazeNaviationSim(GridWorldSimulation):
         self.move_actor = MoveActor(**kwargs)
 
         # Observation Components
-        self.grid_observer = SingleGridObserver(**kwargs)
+        self.grid_observer = AbsoluteGridObserver(**kwargs)
 
         self.finalize()
 

--- a/abmarl/sim/gridworld/observer.py
+++ b/abmarl/sim/gridworld/observer.py
@@ -119,26 +119,19 @@ class AbsoluteGridObserver(ObserverBaseComponent):
                 if mask[r, c]: # We can see this cell
                     candidate_agents = local_grid[r, c]
                     if candidate_agents is None: # This cell is out of bounds
-                        convolved_grid[r, c] = -1 # TODO: I think I can skip this since these cells will be cropped out
+                        continue # Skip this since these cells will be cropped out
                     elif not candidate_agents: # In bounds empty cell
                         convolved_grid[r, c] = 0
                     else: # Observe one of the agents at this cell
-                        # TODO: Adjust some of this logic since the agent will observe itself as a -1
-                        self.observe_self = True
-                        if self.observe_self:
-                            convolved_grid[r, c] = np.random.choice([
-                                other.encoding for other in candidate_agents.values()
-                            ])
+                        # Prioritize observing yourself
+                        if agent.id in candidate_agents:
+                            convolved_grid[r, c] = -1
                         else:
-                            choices = [
+                            convolved_grid[r, c] = np.random.choice([
                                 other.encoding
                                 for other in candidate_agents.values()
                                 if other.id != agent.id
-                            ]
-                            # It may be that the observing agent is the only agent
-                            # at this location but it cannot observe itself, which
-                            # makes choices an empty list.
-                            convolved_grid[r, c] = np.random.choice(choices) if choices else 0
+                            ])
                 else: # Cell blocked by agent. Indicate invisible with -2
                     convolved_grid[r, c] = -2
 
@@ -155,6 +148,7 @@ class AbsoluteGridObserver(ObserverBaseComponent):
         ]
 
         return {self.key: obs}
+
 
 class SingleGridObserver(ObserverBaseComponent):
     """

--- a/abmarl/sim/gridworld/observer.py
+++ b/abmarl/sim/gridworld/observer.py
@@ -83,14 +83,14 @@ class AbsoluteGridObserver(ObserverBaseComponent):
         This Observer's key is "absolute_grid".
         """
         return 'absolute_grid'
-    
+
     @property
     def supported_agent_type(self):
         """
         This Observer work with GridObservingAgents
         """
         return GridObservingAgent
-    
+
     def get_obs(self, agent, **kwargs):
         """
         The agent observes the entire grid.
@@ -102,11 +102,11 @@ class AbsoluteGridObserver(ObserverBaseComponent):
         """
         if not isinstance(agent, self.supported_agent_type):
             return {}
-        
+
         # To generate the observation, we first create a local grid and mask using
         # the agent's view_range. Then we convolve local grid and mask together.
         # Finally, we convolve the masked local grid with the full grid.
- 
+
         # Generate a local grid and an observation mask
         local_grid, mask = gu.create_grid_and_mask(
             agent, self.grid, agent.view_range, self.agents

--- a/abmarl/sim/gridworld/observer.py
+++ b/abmarl/sim/gridworld/observer.py
@@ -56,13 +56,13 @@ class AbsoluteGridObserver(ObserverBaseComponent):
     """
     Observe the entire grid.
 
-    This observation shows agents located on cells by encoding for the entire grid.
+    This Observer shows agents located on cells by encoding for the entire grid.
     If there are multiple agents on a single cell with different encodings, only
     a single randomly chosen encoding will be observed. To be consistent with other
     built-in observers, masked cells are indicated as -2. Typially, -1 is reserved
-    for out of bounds distinction, but because this Observer reports the entire
+    for out of bounds encoding, but because this Observer reports the entire
     grid, we don't need an out of bounds distinction. Instead, in order for the
-    agent to identify itself distinct from other agents of the same encoding, the
+    agent to identify itself distinctly from other agents of the same encoding, the
     observing agent is reported as a -1.
     """
     def __init__(self, **kwargs):
@@ -95,17 +95,17 @@ class AbsoluteGridObserver(ObserverBaseComponent):
         """
         The agent observes the entire grid.
 
-        The observation may include the agent itself, indicated by a -1; other
-        agents; empty space; and masked cells, indicated as -2, which are masked
-        either because they are too far away or because they are blocked from view
-        by view-blocking entities.
+        The observation may include the agent itself indicated by a -1, other
+        agents indicated by their encodings, empty space indicated with a 0, and
+        masked cells indicated as -2, which are masked either because they are
+        too far away or because they are blocked from view by view-blocking agents.
         """
         if not isinstance(agent, self.supported_agent_type):
             return {}
 
         # To generate the observation, we first create a local grid and mask using
         # the agent's view_range. Then we convolve local grid and mask together.
-        # Finally, we convolve the masked local grid with the full grid.
+        # Finally, we subsitute a portion of the full grid with the local grid.
 
         # Generate a local grid and an observation mask
         local_grid, mask = gu.create_grid_and_mask(
@@ -130,7 +130,6 @@ class AbsoluteGridObserver(ObserverBaseComponent):
                             convolved_grid[r, c] = np.random.choice([
                                 other.encoding
                                 for other in candidate_agents.values()
-                                if other.id != agent.id
                             ])
                 else: # Cell blocked by agent. Indicate invisible with -2
                     convolved_grid[r, c] = -2

--- a/abmarl/sim/gridworld/observer.py
+++ b/abmarl/sim/gridworld/observer.py
@@ -123,7 +123,8 @@ class AbsoluteGridObserver(ObserverBaseComponent):
                     elif not candidate_agents: # In bounds empty cell
                         convolved_grid[r, c] = 0
                     else: # Observe one of the agents at this cell
-                        # TODO: Remove some of this logic since the agent will observe itself as a -1
+                        # TODO: Adjust some of this logic since the agent will observe itself as a -1
+                        self.observe_self = True
                         if self.observe_self:
                             convolved_grid[r, c] = np.random.choice([
                                 other.encoding for other in candidate_agents.values()
@@ -148,7 +149,7 @@ class AbsoluteGridObserver(ObserverBaseComponent):
         r_upper = min([self.grid.rows - 1, r + agent.view_range]) + 1
         c_lower = max([0, c - agent.view_range])
         c_upper = min([self.grid.cols - 1, c + agent.view_range]) + 1
-        obs[r_lower:r_upper, c_lower:c_upper] = local_grid[:,:]
+        obs[r_lower:r_upper, c_lower:c_upper] = convolved_grid[:,:] # TODO: resolve the indices issue
 
         return {self.key: convolved_grid}
 

--- a/abmarl/sim/gridworld/observer.py
+++ b/abmarl/sim/gridworld/observer.py
@@ -149,9 +149,12 @@ class AbsoluteGridObserver(ObserverBaseComponent):
         r_upper = min([self.grid.rows - 1, r + agent.view_range]) + 1
         c_lower = max([0, c - agent.view_range])
         c_upper = min([self.grid.cols - 1, c + agent.view_range]) + 1
-        obs[r_lower:r_upper, c_lower:c_upper] = convolved_grid[:,:] # TODO: resolve the indices issue
+        obs[r_lower:r_upper, c_lower:c_upper] = convolved_grid[
+            (r_lower+agent.view_range-r):(r_upper+agent.view_range-r),
+            (c_lower+agent.view_range-c):(c_upper+agent.view_range-c)
+        ]
 
-        return {self.key: convolved_grid}
+        return {self.key: obs}
 
 class SingleGridObserver(ObserverBaseComponent):
     """

--- a/tests/sim/gridworld/test_observer.py
+++ b/tests/sim/gridworld/test_observer.py
@@ -23,6 +23,66 @@ def test_absolute_grid_observer():
             id='agent2', encoding=3, view_range=4, initial_position=np.array([4, 4])
         ),
         'agent3': GridWorldAgent(
+            id='agent3', encoding=5, initial_position=np.array([3, 3])
+        ),
+        'agent4': GridWorldAgent(
+            id='agent4', encoding=4, initial_position=np.array([1, 1])
+        ),
+        'agent5': GridWorldAgent(
+            id='agent5', encoding=6, initial_position=np.array([2, 1])
+        ),
+    }
+
+    position_state = PositionState(grid=grid, agents=agents)
+    observer = AbsoluteGridObserver(agents=agents, grid=grid)
+    assert isinstance(observer, ObserverBaseComponent)
+    position_state.reset()
+
+    np.testing.assert_array_equal(
+        observer.get_obs(agents['agent0'])['absolute_grid'],
+        np.array([
+            [ 2,  0,  0,  0,  0],
+            [ 0,  4,  0,  0,  0],
+            [ 0,  6, -1,  0,  0],
+            [ 0,  0,  0,  5,  0],
+            [ 0,  0,  0,  0,  3]
+        ])
+    )
+    np.testing.assert_array_equal(
+        observer.get_obs(agents['agent1'])['absolute_grid'],
+        np.array([
+            [-1,  0, -2, -2, -2],
+            [ 0,  4, -2, -2, -2],
+            [-2, -2, -2, -2, -2],
+            [-2, -2, -2, -2, -2],
+            [-2, -2, -2, -2, -2]
+        ])
+    )
+    np.testing.assert_array_equal(
+        observer.get_obs(agents['agent2'])['absolute_grid'],
+        np.array([
+            [ 2,  0,  0,  0,  0],
+            [ 0,  4,  0,  0,  0],
+            [ 0,  6,  1,  0,  0],
+            [ 0,  0,  0,  5,  0],
+            [ 0,  0,  0,  0, -1]
+        ])
+    )
+
+
+def test_absolute_grid_observer_blocking():
+    grid = Grid(5, 5)
+    agents = {
+        'agent0': GridObservingAgent(
+            id='agent0', encoding=1, view_range=2, initial_position=np.array([2, 2])
+        ),
+        'agent1': GridObservingAgent(
+            id='agent1', encoding=2, view_range=1, initial_position=np.array([0, 0])
+        ),
+        'agent2': GridObservingAgent(
+            id='agent2', encoding=3, view_range=4, initial_position=np.array([4, 4])
+        ),
+        'agent3': GridWorldAgent(
             id='agent3', encoding=5, initial_position=np.array([3, 3]), blocking=True
         ),
         'agent4': GridWorldAgent(

--- a/tests/sim/gridworld/test_observer.py
+++ b/tests/sim/gridworld/test_observer.py
@@ -11,7 +11,7 @@ from abmarl.sim.gridworld.grid import Grid
 
 
 def test_absolute_grid_observer():
-    grid = Grid(5, 5)
+    grid = Grid(5, 5, overlapping={1: [6], 6: [1]})
     agents = {
         'agent0': GridObservingAgent(
             id='agent0', encoding=1, view_range=2, initial_position=np.array([2, 2])
@@ -30,6 +30,9 @@ def test_absolute_grid_observer():
         ),
         'agent5': GridWorldAgent(
             id='agent5', encoding=6, initial_position=np.array([2, 1])
+        ),
+        'agent6': GridWorldAgent(
+            id='agent6', encoding=6, initial_position=np.array([2, 2])
         ),
     }
 
@@ -63,7 +66,7 @@ def test_absolute_grid_observer():
         np.array([
             [ 2,  0,  0,  0,  0],
             [ 0,  4,  0,  0,  0],
-            [ 0,  6,  1,  0,  0],
+            [ 0,  6,  6,  0,  0],
             [ 0,  0,  0,  5,  0],
             [ 0,  0,  0,  0, -1]
         ])
@@ -71,7 +74,7 @@ def test_absolute_grid_observer():
 
 
 def test_absolute_grid_observer_blocking():
-    grid = Grid(5, 5)
+    grid = Grid(5, 5, overlapping={1: [6], 6: [1]})
     agents = {
         'agent0': GridObservingAgent(
             id='agent0', encoding=1, view_range=2, initial_position=np.array([2, 2])
@@ -90,6 +93,9 @@ def test_absolute_grid_observer_blocking():
         ),
         'agent5': GridWorldAgent(
             id='agent5', encoding=6, initial_position=np.array([2, 1]), blocking=True
+        ),
+        'agent6': GridWorldAgent(
+            id='agent6', encoding=6, initial_position=np.array([2, 2])
         ),
     }
 

--- a/tests/sim/gridworld/test_observer.py
+++ b/tests/sim/gridworld/test_observer.py
@@ -3,11 +3,71 @@ from gym.spaces import Box
 import numpy as np
 
 from abmarl.sim.agent_based_simulation import ObservingAgent
-from abmarl.sim.gridworld.observer import ObserverBaseComponent, SingleGridObserver, \
-    MultiGridObserver, AbsolutePositionObserver
+from abmarl.sim.gridworld.observer import ObserverBaseComponent, AbsoluteGridObserver, \
+    SingleGridObserver, MultiGridObserver, AbsolutePositionObserver
 from abmarl.sim.gridworld.agent import GridObservingAgent, GridWorldAgent, MovingAgent
 from abmarl.sim.gridworld.state import PositionState
 from abmarl.sim.gridworld.grid import Grid
+
+
+def test_absolute_grid_observer():
+    grid = Grid(5, 5)
+    agents = {
+        'agent0': GridObservingAgent(
+            id='agent0', encoding=1, view_range=2, initial_position=np.array([2, 2])
+        ),
+        'agent1': GridObservingAgent(
+            id='agent1', encoding=2, view_range=1, initial_position=np.array([0, 0])
+        ),
+        'agent2': GridObservingAgent(
+            id='agent2', encoding=3, view_range=4, initial_position=np.array([4, 4])
+        ),
+        'agent3': GridWorldAgent(
+            id='agent3', encoding=5, initial_position=np.array([3, 3]), blocking=True
+        ),
+        'agent4': GridWorldAgent(
+            id='agent4', encoding=4, initial_position=np.array([1, 1]), blocking=True
+        ),
+        'agent5': GridWorldAgent(
+            id='agent5', encoding=6, initial_position=np.array([2, 1]), blocking=True
+        ),
+    }
+
+    position_state = PositionState(grid=grid, agents=agents)
+    observer = AbsoluteGridObserver(agents=agents, grid=grid)
+    assert isinstance(observer, ObserverBaseComponent)
+    position_state.reset()
+
+    np.testing.assert_array_equal(
+        observer.get_obs(agents['agent0'])['absolute_grid'],
+        np.array([
+            [-2, -2,  0,  0,  0],
+            [-2,  4,  0,  0,  0],
+            [-2,  6, -1,  0,  0],
+            [-2,  0,  0,  5, -2],
+            [ 0,  0,  0, -2, -2]
+        ])
+    )
+    np.testing.assert_array_equal(
+        observer.get_obs(agents['agent1'])['absolute_grid'],
+        np.array([
+            [-1,  0, -2, -2, -2],
+            [ 0,  4, -2, -2, -2],
+            [-2, -2, -2, -2, -2],
+            [-2, -2, -2, -2, -2],
+            [-2, -2, -2, -2, -2]
+        ])
+    )
+    np.testing.assert_array_equal(
+        observer.get_obs(agents['agent2'])['absolute_grid'],
+        np.array([
+            [-2, -2, -2,  0,  0],
+            [-2, -2, -2,  0,  0],
+            [-2, -2, -2, -2,  0],
+            [ 0,  0, -2,  5,  0],
+            [ 0,  0,  0,  0, -1]
+        ])
+    )
 
 
 def test_single_grid_observer():

--- a/tests/sim/gridworld/test_observer.py
+++ b/tests/sim/gridworld/test_observer.py
@@ -11,6 +11,7 @@ from abmarl.sim.gridworld.grid import Grid
 
 
 def test_absolute_grid_observer():
+    np.random.seed(24)
     grid = Grid(5, 5, overlapping={1: [6], 6: [1]})
     agents = {
         'agent0': GridObservingAgent(
@@ -66,7 +67,7 @@ def test_absolute_grid_observer():
         np.array([
             [ 2,  0,  0,  0,  0],
             [ 0,  4,  0,  0,  0],
-            [ 0,  6,  6,  0,  0],
+            [ 0,  6,  1,  0,  0],
             [ 0,  0,  0,  5,  0],
             [ 0,  0,  0,  0, -1]
         ])
@@ -74,6 +75,7 @@ def test_absolute_grid_observer():
 
 
 def test_absolute_grid_observer_blocking():
+    np.random.seed(24)
     grid = Grid(5, 5, overlapping={1: [6], 6: [1]})
     agents = {
         'agent0': GridObservingAgent(


### PR DESCRIPTION
Agents can observe the full grid with the usual masking rules

- [x] Need to add a test where the agent is overlapping another agent and it observes itself
- [x] ~~Single- and Multi-Grid observers need to change their key to something besides just 'grid'~~
Covered in #373 

Resolves #363