### PR TITLE
Abmarl 347 build from grid with extra agents

### DIFF
--- a/abmarl/sim/gridworld/base.py
+++ b/abmarl/sim/gridworld/base.py
@@ -41,19 +41,30 @@ class GridWorldSimulation(AgentBasedSimulation, ABC):
         return cls._build_sim(rows, cols, **kwargs)
 
     @classmethod
-    def build_sim_from_grid(cls, grid, **kwargs):
+    def build_sim_from_grid(cls, grid, extra_agents=None, **kwargs):
         """
         Build a GridSimluation from a Grid object.
 
         Args:
             grid: A Grid contains the all the agents index by location, so we can
                 construct a simluation from it.
+            extra_agents: A dictionary of agents which are not in the input grid
+                but which we want to be a part of the simulation. Note: if there
+                is an agent in the grid and in extra_agents, we will use the one
+                from the grid.
 
         Returns:
-            A GridSimulation built from the grid.
+            A GridSimulation built from the grid along with any extra agents.
         """
         assert type(grid) is Grid, "Grid object required."
-        agents = {}
+        if extra_agents is not None:
+            # We only check if it is a dictionary because that is the requirement
+            # here. The ABM agents property will further check the contents of the
+            # dictionary as needed.
+            assert type(extra_agents) is dict, "Extra agents must be a dictionary."
+            agents = extra_agents
+        else:
+            agents = {}
         for r in range(grid.rows):
             for c in range(grid.cols):
                 if grid[r, c] is not None:
@@ -64,12 +75,14 @@ class GridWorldSimulation(AgentBasedSimulation, ABC):
                             np.array([r, c])
                         ), "The initial position of the agent must match its position in the grid."
 
+        # TODO: Don't put these in kwargs, just pass them directly.
+        # TODO: Use _build_sim because it puts the grid in the correct start state.
         kwargs['grid'] = grid
         kwargs['agents'] = agents
         return cls(**kwargs)
 
     @classmethod
-    def build_sim_from_array(cls, array, object_registry, **kwargs):
+    def build_sim_from_array(cls, array, object_registry, extra_agents=None, **kwargs):
         """
         Build a GridSimulation from an array.
 
@@ -80,16 +93,26 @@ class GridWorldSimulation(AgentBasedSimulation, ABC):
             object_registry: A dictionary that maps the characters in the array
                 to a function that generates the agent with its unique id. Zeros,
                 periods, and underscores are reserved for empty space.
+            extra_agents: A dictionary of agents which are not in the input grid
+                but which we want to be a part of the simulation. Note: if there
+                is an agent in the array and in extra_agents, we will use the one
+                from the array.
 
         Returns:
-            A GridSimulation built from the array.
+            A GridSimulation built from the array along with any extra agents.
         """
-        # TODO: Support arrays that contain an iterable of characters per cell
         assert type(array) is np.ndarray, "The array must be a numpy array."
         assert type(object_registry) is dict, "The object_registry must be a dictionary."
         assert all([i not in object_registry for i in [0, '.', '_']]), \
             "0, '.', and '_' are reserved for empty space."
-        agents = {}
+        if extra_agents is not None:
+            # We only check if it is a dictionary because that is the requirement
+            # here. The ABM agents property will further check the contents of the
+            # dictionary as needed.
+            assert type(extra_agents) is dict, "Extra agents must be a dictionary."
+            agents = extra_agents
+        else:
+            agents = {}
         n = 0
         rows = array.shape[0]
         cols = array.shape[1]
@@ -105,7 +128,7 @@ class GridWorldSimulation(AgentBasedSimulation, ABC):
         return cls._build_sim(rows, cols, agents=agents, **kwargs)
 
     @classmethod
-    def build_sim_from_file(cls, file_name, object_registry, **kwargs):
+    def build_sim_from_file(cls, file_name, object_registry, extra_agents=None, **kwargs):
         """
         Build a GridSimulation from a text file.
 
@@ -118,15 +141,26 @@ class GridWorldSimulation(AgentBasedSimulation, ABC):
                 function that generates the agent. This must be a function because
                 each agent must have unique id, which is generated here. Zeros,
                 periods, and underscores are reserved for empty space.
+            extra_agents: A dictionary of agents which are not in the input grid
+                but which we want to be a part of the simulation. Note: if there
+                is an agent in the file and in extra_agents, we will use the one
+                from the file.
 
         Returns:
-            A GridSimulation built from the file.
+            A GridSimulation built from the file along with any extra agents.
         """
         assert type(file_name) is str, "The file_name must be the name of the file."
         assert type(object_registry) is dict, "The object_registry must be a dictionary."
         assert all([i not in object_registry for i in [0, '.', '_']]), \
             "0, '.', and '_' are reserved for empty space."
-        agents = {}
+        if extra_agents is not None:
+            # We only check if it is a dictionary because that is the requirement
+            # here. The ABM agents property will further check the contents of the
+            # dictionary as needed.
+            assert type(extra_agents) is dict, "Extra agents must be a dictionary."
+            agents = extra_agents
+        else:
+            agents = {}
         n = 0
         with open(file_name, 'r') as fp:
             lines = fp.read().splitlines()

--- a/abmarl/sim/gridworld/base.py
+++ b/abmarl/sim/gridworld/base.py
@@ -75,11 +75,7 @@ class GridWorldSimulation(AgentBasedSimulation, ABC):
                             np.array([r, c])
                         ), "The initial position of the agent must match its position in the grid."
 
-        # TODO: Don't put these in kwargs, just pass them directly.
-        # TODO: Use _build_sim because it puts the grid in the correct start state.
-        kwargs['grid'] = grid
-        kwargs['agents'] = agents
-        return cls(**kwargs)
+        return cls._build_sim(grid.rows, grid.cols, agents=agents, **kwargs)
 
     @classmethod
     def build_sim_from_array(cls, array, object_registry, extra_agents=None, **kwargs):
@@ -181,8 +177,7 @@ class GridWorldSimulation(AgentBasedSimulation, ABC):
     @classmethod
     def _build_sim(cls, rows, cols, **kwargs):
         grid = Grid(rows, cols, **kwargs)
-        kwargs['grid'] = grid
-        return cls(**kwargs)
+        return cls(grid=grid, **kwargs)
 
     def render(self, fig=None, **kwargs):
         """

--- a/tests/sim/gridworld/test_base.py
+++ b/tests/sim/gridworld/test_base.py
@@ -57,6 +57,7 @@ def test_build_from_grid():
     grid.place(agents[3], (1, 1))
 
     sim = MultiAgentGridSim.build_sim_from_grid(grid)
+    sim.reset()
     assert sim.agents == {
         'agent0': agents[0],
         'agent1': agents[1],
@@ -79,12 +80,6 @@ def test_build_from_grid():
         sim.agents['agent3'].initial_position,
         np.array([1, 1])
     )
-    assert next(iter(sim.grid[0, 0].values())) == agents[0]
-    assert next(iter(sim.grid[0, 1].values())) == agents[1]
-    assert next(iter(sim.grid[1, 0].values())) == agents[2]
-    assert next(iter(sim.grid[1, 1].values())) == agents[3]
-
-    sim.reset()
     assert next(iter(sim.grid[0, 0].values())) == agents[0]
     assert next(iter(sim.grid[0, 1].values())) == agents[1]
     assert next(iter(sim.grid[1, 0].values())) == agents[2]

--- a/tests/sim/gridworld/test_base.py
+++ b/tests/sim/gridworld/test_base.py
@@ -179,9 +179,6 @@ def test_build_from_grid_with_extra_agents():
         # This fails because the agents are not allowed to overlap
         sim2.reset()
 
-    with pytest.raises(AssertionError):
-        MultiAgentGridSim.build_sim_from_grid(grid._internal)
-
 
 def test_build_sim_from_array():
     array = np.array([

--- a/tests/sim/gridworld/test_base.py
+++ b/tests/sim/gridworld/test_base.py
@@ -42,27 +42,24 @@ def test_build():
 def test_build_from_grid():
     grid = Grid(2, 2)
     grid.reset()
-    agents = [
-        GridWorldAgent(id='agent0', encoding=1, initial_position=np.array([0, 0])),
-        GridWorldAgent(id='agent1', encoding=1, initial_position=np.array([0, 1])),
-        GridWorldAgent(id='agent2', encoding=1, initial_position=np.array([1, 0])),
-        GridWorldAgent(id='agent3', encoding=1, initial_position=np.array([1, 1])),
-    ]
-    # Place 0th and 3rd agent in the grid according to their initial positions.
-    # Place 1st and 2nd agent in the grid swapped. We want to test how the
-    # initial positions gets defined during the build process.
-    grid.place(agents[0], (0, 0))
-    grid.place(agents[1], (0, 1))
-    grid.place(agents[2], (1, 0))
-    grid.place(agents[3], (1, 1))
+    agents = {
+        'agent0': GridWorldAgent(id='agent0', encoding=1, initial_position=np.array([0, 0])),
+        'agent1': GridWorldAgent(id='agent1', encoding=1, initial_position=np.array([0, 1])),
+        'agent2': GridWorldAgent(id='agent2', encoding=1, initial_position=np.array([1, 0])),
+        'agent3': GridWorldAgent(id='agent3', encoding=1, initial_position=np.array([1, 1])),
+    }
+    grid.place(agents['agent0'], (0, 0))
+    grid.place(agents['agent1'], (0, 1))
+    grid.place(agents['agent2'], (1, 0))
+    grid.place(agents['agent3'], (1, 1))
 
     sim = MultiAgentGridSim.build_sim_from_grid(grid)
     sim.reset()
     assert sim.agents == {
-        'agent0': agents[0],
-        'agent1': agents[1],
-        'agent2': agents[2],
-        'agent3': agents[3],
+        'agent0': agents['agent0'],
+        'agent1': agents['agent1'],
+        'agent2': agents['agent2'],
+        'agent3': agents['agent3'],
     }
     np.testing.assert_array_equal(
         sim.agents['agent0'].initial_position,
@@ -80,17 +77,20 @@ def test_build_from_grid():
         sim.agents['agent3'].initial_position,
         np.array([1, 1])
     )
-    assert next(iter(sim.grid[0, 0].values())) == agents[0]
-    assert next(iter(sim.grid[0, 1].values())) == agents[1]
-    assert next(iter(sim.grid[1, 0].values())) == agents[2]
-    assert next(iter(sim.grid[1, 1].values())) == agents[3]
+    assert next(iter(sim.grid[0, 0].values())) == agents['agent0']
+    assert next(iter(sim.grid[0, 1].values())) == agents['agent1']
+    assert next(iter(sim.grid[1, 0].values())) == agents['agent2']
+    assert next(iter(sim.grid[1, 1].values())) == agents['agent3']
 
     with pytest.raises(AssertionError):
+        # This fails because the grid must be a grid object, not an array
         MultiAgentGridSim.build_sim_from_grid(grid._internal)
 
     with pytest.raises(AssertionError):
-        agents[1].initial_position = np.array([1, 0])
-        agents[2].initial_position = np.array([0, 1])
+        # This fails becaue the agents' initial positions must match their index
+        # within the grid.
+        agents['agent1'].initial_position = np.array([1, 0])
+        agents['agent2'].initial_position = np.array([0, 1])
         MultiAgentGridSim.build_sim_from_grid(grid)
 
 

--- a/tests/sim/gridworld/test_base.py
+++ b/tests/sim/gridworld/test_base.py
@@ -305,7 +305,6 @@ def test_build_sim_from_array():
 
 
 def test_build_sim_from_array_with_extra_agents():
-    np.random.seed(24)
     array = np.array([
         ['A', '.', 'B', '0', ''],
         ['B', '_', '', 'C', 'A']
@@ -551,3 +550,130 @@ def test_build_sim_from_file():
             ),
         })
         MultiAgentGridSim.build_sim_from_file(file_name, obj_registry)
+
+
+def test_build_sim_from_file_with_extra_agents():
+    file_name = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        'grid_file.txt'
+    )
+    obj_registry = {
+        'A': lambda n: GridWorldAgent(
+            id=f'A-class-barrier{n}',
+            encoding=1,
+        ),
+        'B': lambda n: GridWorldAgent(
+            id=f'B-class-barrier{n}',
+            encoding=2,
+        ),
+        'C': lambda n: GridWorldAgent(
+            id=f'C-class-barrier{n}',
+            encoding=3,
+        ),
+    }
+    # B-class-barrier2 exists in the file, so the builder should not use the one
+    # in extra_agents
+    # extra_agent0 and 1 will exist because they can overlap
+    # extra_agent2 will exist because it occupies an empty space
+    extra_agents = {
+        'B-class-barrier2': GridWorldAgent(
+            id='B-class-barrier2',
+            encoding=4,
+            initial_position=np.array([1, 0])
+        ),
+        'extra_agent0': GridWorldAgent(
+            id='extra_agent0',
+            encoding=5,
+            initial_position=np.array([0, 0])
+        ),
+        'extra_agent1': GridWorldAgent(
+            id='extra_agent1',
+            encoding=5,
+            initial_position=np.array([0, 0])
+        ),
+        'extra_agent2': GridWorldAgent(
+            id='extra_agent2',
+            encoding=6,
+            initial_position=np.array([0, 4])
+        )
+    }
+    sim = MultiAgentGridSim.build_sim_from_file(
+        file_name,
+        obj_registry,
+        extra_agents=extra_agents,
+        overlapping={1: [5], 5: [1, 5]}
+    )
+    sim.reset()
+    assert 'A-class-barrier0' in sim.grid[0, 0]
+    assert 'extra_agent0' in sim.grid[0, 0]
+    assert 'extra_agent1' in sim.grid[0, 0]
+    assert sim.grid[0, 1] == {}
+    assert 'B-class-barrier1' in sim.grid[0, 2]
+    assert sim.grid[0, 3] == {}
+    assert next(iter(sim.grid[0, 4].values())) == extra_agents['extra_agent2']
+    assert 'B-class-barrier2' in sim.grid[1, 0]
+    assert next(iter(sim.grid[1, 0].values())).encoding == 2
+    assert sim.grid[1, 1] == {}
+    assert sim.grid[1, 2] == {}
+    assert 'C-class-barrier3' in sim.grid[1, 3]
+    assert 'A-class-barrier4' in sim.grid[1, 4]
+
+    assert len(sim.agents) == 8
+    assert sim.agents['A-class-barrier0'].encoding == 1
+    np.testing.assert_array_equal(
+        sim.agents['A-class-barrier0'].initial_position,
+        np.array([0, 0])
+    )
+    assert sim.agents['B-class-barrier1'].encoding == 2
+    np.testing.assert_array_equal(
+        sim.agents['B-class-barrier1'].initial_position,
+        np.array([0, 2])
+    )
+    assert sim.agents['B-class-barrier2'].encoding == 2
+    np.testing.assert_array_equal(
+        sim.agents['B-class-barrier2'].initial_position,
+        np.array([1, 0])
+    )
+    assert sim.agents['C-class-barrier3'].encoding == 3
+    np.testing.assert_array_equal(
+        sim.agents['C-class-barrier3'].initial_position,
+        np.array([1, 3])
+    )
+    assert sim.agents['A-class-barrier4'].encoding == 1
+    np.testing.assert_array_equal(
+        sim.agents['A-class-barrier4'].initial_position,
+        np.array([1, 4])
+    )
+    assert sim.agents['extra_agent0'].encoding == 5
+    np.testing.assert_array_equal(
+        sim.agents['extra_agent0'].initial_position,
+        np.array([0, 0])
+    )
+    assert sim.agents['extra_agent1'].encoding == 5
+    np.testing.assert_array_equal(
+        sim.agents['extra_agent1'].initial_position,
+        np.array([0, 0])
+    )
+    assert sim.agents['extra_agent2'].encoding == 6
+    np.testing.assert_array_equal(
+        sim.agents['extra_agent2'].initial_position,
+        np.array([0, 4])
+    )
+
+    with pytest.raises(AssertionError):
+        # This fails because extra agents must be a dict
+        MultiAgentGridSim.build_sim_from_file(file_name, obj_registry, extra_agents=[])
+
+    with pytest.raises(AssertionError):
+        # This fails because the contents of the extra_agents dict is wrong.
+        MultiAgentGridSim.build_sim_from_file(file_name, obj_registry, extra_agents={0: 1})
+
+    sim2 = MultiAgentGridSim.build_sim_from_file(
+        file_name,
+        obj_registry,
+        extra_agents=extra_agents,
+        overlapping={1: [5], 5: [1]}
+    )
+    with pytest.raises(AssertionError):
+        # This fails because 5 cannot overlap with 5
+        sim2.reset()


### PR DESCRIPTION
Builders can build the simulation from the grid/array/file and also populate it with additional agents. The additional agents don't need to have initial positions. Overlapping rules apply as normal. If there an agent is specified in the grid/array/file and in the extra_agents, the builder will use the properties from the grid/array/file (and the extra agents dict will itself be updated to reflect those properties since it is passed by reference and not deep-copied).

Resolves #347 