### PR TITLE
Abmarl 397 super agent wrapper with rllib

### DIFF
--- a/abmarl/sim/wrappers/super_agent_wrapper.py
+++ b/abmarl/sim/wrappers/super_agent_wrapper.py
@@ -1,7 +1,7 @@
 
 import warnings
 
-from gym.spaces import Dict, Discrete
+from gym.spaces import Dict, MultiBinary
 
 from abmarl.sim.agent_based_simulation import Agent
 from abmarl.sim.wrappers import Wrapper
@@ -153,14 +153,14 @@ class SuperAgentWrapper(Wrapper):
                 if self.sim.get_done(covered_agent, **kwargs):
                     if self._last_obs_reported[covered_agent]:
                         obs[covered_agent] = self._get_null_obs(covered_agent, **kwargs)
-                        obs['mask'][covered_agent] = False
+                        obs['mask'][covered_agent] = [False]
                     else:
                         obs[covered_agent] = self.sim.get_obs(covered_agent, **kwargs)
-                        obs['mask'][covered_agent] = False
+                        obs['mask'][covered_agent] = [False]
                         self._last_obs_reported[covered_agent] = True
                 else:
                     obs[covered_agent] = self.sim.get_obs(covered_agent, **kwargs)
-                    obs['mask'][covered_agent] = True
+                    obs['mask'][covered_agent] = [True]
             return obs
         else:
             return self.sim.get_obs(agent_id, **kwargs)
@@ -253,7 +253,7 @@ class SuperAgentWrapper(Wrapper):
             obs_mapping = {'mask': {}}
             for covered_agent_id in covered_agent_list:
                 obs_mapping[covered_agent_id] = self.sim.agents[covered_agent_id].observation_space
-                obs_mapping['mask'][covered_agent_id] = Discrete(2)
+                obs_mapping['mask'][covered_agent_id] = MultiBinary(1)
             action_mapping = {
                 covered_agent_id: self.sim.agents[covered_agent_id].action_space
                 for covered_agent_id in covered_agent_list

--- a/examples/team_battle_example.py
+++ b/examples/team_battle_example.py
@@ -78,6 +78,7 @@ params = {
             'episodes_total': 2000,
         },
         'verbose': 2,
+        'local_dir': 'output_dir',
         'config': {
             # --- Simulation ---
             'disable_env_checking': False,

--- a/examples/team_battle_super_agent.py
+++ b/examples/team_battle_super_agent.py
@@ -51,7 +51,7 @@ sim_ = AllStepManager(
 sim = MultiAgentWrapper(sim_)
 
 
-sim_name = "TeamBattle"
+sim_name = "TeamBattleSuperAgent"
 from ray.tune.registry import register_env
 register_env(sim_name, lambda sim_config: sim)
 
@@ -82,6 +82,7 @@ params = {
             'episodes_total': 2000,
         },
         'verbose': 2,
+        'local_dir': 'output_dir',
         'config': {
             # --- Simulation ---
             'disable_env_checking': False,

--- a/tests/sim/wrappers/test_super_agent_wrapper.py
+++ b/tests/sim/wrappers/test_super_agent_wrapper.py
@@ -1,7 +1,7 @@
 
 import warnings
 
-from gym.spaces import Discrete, Dict
+from gym.spaces import MultiBinary, Dict
 import pytest
 
 from abmarl.sim.wrappers import SuperAgentWrapper
@@ -83,7 +83,7 @@ def test_agent_spaces():
     assert agents['super0'].observation_space == Dict({
         'agent0': original_agents['agent0'].observation_space,
         'agent3': original_agents['agent3'].observation_space,
-        'mask': Dict({'agent0': Discrete(2), 'agent3': Discrete(2)})
+        'mask': Dict({'agent0': MultiBinary(1), 'agent3': MultiBinary(1)})
     })
     assert agents['agent1'] == original_agents['agent1']
     assert agents['agent2'] == original_agents['agent2']
@@ -155,7 +155,7 @@ def test_sim_obs():
     assert obs == {
         'agent0': [0, 0, 0, 1],
         'agent3': {'first': 1, 'second': [3, 1]},
-        'mask': {'agent0': False, 'agent3': True}
+        'mask': {'agent0': [False], 'agent3': [True]}
     }
 
     obs = sim.get_obs('agent1')
@@ -234,7 +234,7 @@ def test_double_wrap():
     assert sim2.agents['double0'].observation_space == Dict({
         'super0': sim2.sim.agents['super0'].observation_space,
         'agent1': sim2.sim.agents['agent1'].observation_space,
-        'mask': Dict({'super0': Discrete(2), 'agent1': Discrete(2)})
+        'mask': Dict({'super0': MultiBinary(1), 'agent1': MultiBinary(1)})
     })
     assert sim2.agents['agent2'] == original_agents['agent2']
     assert sim2.agents['agent4'] == original_agents['agent4']
@@ -270,10 +270,10 @@ def test_double_wrap():
         'super0': {
             'agent0': [0, 0, 0, 1],
             'agent3': {'first': 1, 'second': [3, 1]},
-            'mask': {'agent0': True, 'agent3': True}
+            'mask': {'agent0': [True], 'agent3': [True]}
         },
         'agent1': [0],
-        'mask': {'agent1': True, 'super0': True}
+        'mask': {'agent1': [True], 'super0': [True]}
     }
     obs = sim2.get_obs('agent2')
     assert obs in sim2.agents['agent2'].observation_space
@@ -303,7 +303,7 @@ def test_using_null_obs_when_done():
     assert obs == {
         'agent0': [0, 0, 0, 1],
         'agent3': {'first': 1, 'second': [3, 1]},
-        'mask': {'agent0': True, 'agent3': True}
+        'mask': {'agent0': [True], 'agent3': [True]}
     }
 
 
@@ -320,12 +320,12 @@ def test_using_null_obs_when_done():
     assert sim.get_obs('super0') == {
         'agent0': [0, 0, 0, 1],
         'agent3': {'first': 1, 'second': [3, 1]},
-        'mask': {'agent0': False, 'agent3': True}
+        'mask': {'agent0': [False], 'agent3': [True]}
     }
     assert sim.get_obs('super0') == {
         'agent0': [0, 0, 0, 0],
         'agent3': {'first': 1, 'second': [3, 1]},
-        'mask': {'agent0': False, 'agent3': True}
+        'mask': {'agent0': [False], 'agent3': [True]}
     }
     assert sim.unwrapped.get_obs('agent0') == [0, 0, 0, 1]
 
@@ -342,12 +342,12 @@ def test_using_null_obs_when_done():
     assert sim.get_obs('super0') == {
         'agent0': [0, 0, 0, 0],
         'agent3': {'first': 1, 'second': [3, 1]},
-        'mask': {'agent0': False, 'agent3': False}
+        'mask': {'agent0': [False], 'agent3': [False]}
     }
     assert sim.get_obs('super0') == {
         'agent0': [0, 0, 0, 0],
         'agent3': {'first': 1, 'second': [3, 1]},
-        'mask': {'agent0': False, 'agent3': False}
+        'mask': {'agent0': [False], 'agent3': [False]}
     }
     assert sim.get_reward('super0') == 7
     assert sim.get_reward('super0') == 0


### PR DESCRIPTION
Resolves #397 by using MultiBinary space for the mask instead of Discrete because rllib doesn't like the way I do the one-hot-encoding