### PR TITLE
agents have render size and more options for gridworld sim

### DIFF
--- a/abmarl/sim/gridworld/agent.py
+++ b/abmarl/sim/gridworld/agent.py
@@ -9,13 +9,14 @@ class GridWorldAgent(PrincipleAgent):
     The base agent in the GridWorld.
     """
     def __init__(self, initial_position=None, blocking=False, encoding=None, render_shape='o',
-                 render_color='gray', **kwargs):
+                 render_color='gray', render_size=200, **kwargs):
         super().__init__(**kwargs)
         self.encoding = encoding
         self.initial_position = initial_position
         self.blocking = blocking
         self.render_shape = render_shape
         self.render_color = render_color
+        self.render_size = render_size
 
     @property
     def encoding(self):
@@ -100,10 +101,22 @@ class GridWorldAgent(PrincipleAgent):
         self._render_color = value
 
     @property
+    def render_size(self):
+        """
+        The agent's size in the rendered grid.
+        """
+        return self._render_size
+
+    @render_size.setter
+    def render_size(self, value):
+        assert type(value) is int and value > 0, "Render size must be nonnegative integer."
+        self._render_size = value
+
+    @property
     def configured(self):
         return super().configured and self.encoding is not None and \
             self.blocking is not None and self.render_shape is not None and \
-            self.render_color is not None
+            self.render_size is not None
 
 
 class GridObservingAgent(ObservingAgent, GridWorldAgent):

--- a/abmarl/sim/gridworld/base.py
+++ b/abmarl/sim/gridworld/base.py
@@ -197,7 +197,7 @@ class GridWorldSimulation(AgentBasedSimulation, ABC):
         grid = Grid(rows, cols, **kwargs)
         return cls(grid=grid, **kwargs)
 
-    def render(self, fig=None, **kwargs):
+    def render(self, fig=None, gridlines=True, background_color='w', **kwargs):
         """
         Draw the grid and all active agents in the grid.
 
@@ -208,6 +208,8 @@ class GridWorldSimulation(AgentBasedSimulation, ABC):
                 to provide this figure because the same figure must be used when drawing
                 each state of the simulation. Otherwise, a ton of figures will pop up,
                 which is very annoying.
+            gridlines: If true, then draw the gridlines.
+            background_color: The background color of the grid, default is white.
         """
         draw_now = fig is None
         if draw_now:
@@ -216,12 +218,14 @@ class GridWorldSimulation(AgentBasedSimulation, ABC):
 
         fig.clear()
         ax = fig.gca()
+        ax.set_facecolor(background_color)
 
         # Draw the gridlines
         ax.set(xlim=(0, self.grid.cols), ylim=(0, self.grid.rows))
         ax.set_xticks(np.arange(0, self.grid.cols, 1))
         ax.set_yticks(np.arange(0, self.grid.rows, 1))
-        ax.grid()
+        if gridlines:
+            ax.grid()
 
         # Draw the agents
         agents_x = [
@@ -233,7 +237,8 @@ class GridWorldSimulation(AgentBasedSimulation, ABC):
         ]
         shape = [agent.render_shape for agent in self.agents.values() if agent.active]
         color = [agent.render_color for agent in self.agents.values() if agent.active]
-        mscatter(agents_x, agents_y, ax=ax, m=shape, s=200, facecolor=color)
+        size = [agent.render_size for agent in self.agents.values() if agent.active]
+        mscatter(agents_x, agents_y, ax=ax, m=shape, s=size, facecolor=color)
 
         if draw_now:
             plt.plot()

--- a/tests/sim/gridworld/test_agent.py
+++ b/tests/sim/gridworld/test_agent.py
@@ -21,6 +21,7 @@ def test_grid_world_agent():
     assert agent.encoding == 4
     assert agent.render_shape == 'o'
     assert agent.render_color == 'gray'
+    assert agent.render_size == 200
     assert agent.configured
 
     # Encoding
@@ -74,6 +75,13 @@ def test_grid_world_agent():
         agent = GridWorldAgent(
             id='agent',
             render_shape='circle'
+        )
+
+    # Render size
+    with pytest.raises(AssertionError):
+        agent = GridWorldAgent(
+            id='agent',
+            render_size=-3
         )
 
 


### PR DESCRIPTION
scatter already handles agent size, we just needed to leverage it.

Resolves #478