### PR TITLE
Adjust default output directory for pacman example

### DIFF
--- a/examples/rllib_pacman.py
+++ b/examples/rllib_pacman.py
@@ -86,6 +86,7 @@ params = {
             'episodes_total': 200_000,
         },
         'verbose': 2,
+        'local_dir': '../../',
         'config': {
             # --- Simulation ---
             'disable_env_checking': False,


### PR DESCRIPTION
Uses a relative path - assumes example is run from [root]/Abmarl/examples and then saves to [root]/abmarl_results