### PR TITLE
Abmarl 476 obj reg improvements

### DIFF
--- a/abmarl/examples/sim/pacman.py
+++ b/abmarl/examples/sim/pacman.py
@@ -260,60 +260,60 @@ class PacmanSimSimple(PacmanSim):
 
         # Define baddie actions
         action_dict = {
-            'baddie_20': {'move': 0},
-            'baddie_36': {'move': 0},
-            'baddie_156': {'move': 0},
-            'baddie_157': {'move': 1},
-            'baddie_159': {'move': np.random.randint(0, 5)},
-            'baddie_161': {'move': 3},
-            'baddie_162': {'move': 0},
-            'baddie_206': {'move': 0},
-            'baddie_222': {'move': 0},
-            'baddie_328': {'move': 0},
+            'baddie_0': {'move': 0},
+            'baddie_1': {'move': 0},
+            'baddie_2': {'move': 0},
+            'baddie_3': {'move': 1},
+            'baddie_4': {'move': np.random.randint(0, 5)},
+            'baddie_5': {'move': 3},
+            'baddie_6': {'move': 0},
+            'baddie_7': {'move': 0},
+            'baddie_8': {'move': 0},
+            'baddie_9': {'move': 0},
         }
         if self.step_count == 0:
-            action_dict['baddie_156']['move'] = 4
-            action_dict['baddie_162']['move'] = 4
-            action_dict['baddie_328']['move'] = 3
+            action_dict['baddie_2']['move'] = 4
+            action_dict['baddie_6']['move'] = 4
+            action_dict['baddie_9']['move'] = 3
         if self.step_count % 10 == 0:
-            action_dict['baddie_20']['move'] = 3
-            action_dict['baddie_36']['move'] = 1
+            action_dict['baddie_0']['move'] = 3
+            action_dict['baddie_1']['move'] = 1
         elif self.step_count % 10 == 3:
-            action_dict['baddie_20']['move'] = 2
-            action_dict['baddie_36']['move'] = 2
+            action_dict['baddie_0']['move'] = 2
+            action_dict['baddie_1']['move'] = 2
         elif self.step_count % 10 == 5:
-            action_dict['baddie_20']['move'] = 1
-            action_dict['baddie_36']['move'] = 3
+            action_dict['baddie_0']['move'] = 1
+            action_dict['baddie_1']['move'] = 3
         elif self.step_count % 10 == 8:
-            action_dict['baddie_20']['move'] = 4
-            action_dict['baddie_36']['move'] = 4
+            action_dict['baddie_0']['move'] = 4
+            action_dict['baddie_1']['move'] = 4
         if (self.step_count - 8) % 16 == 0:
-            if self.agents['baddie_156'].orientation == 4:
-                action_dict['baddie_156']['move'] = 2
-                action_dict['baddie_162']['move'] = 2
-                action_dict['baddie_328']['move'] = 3
+            if self.agents['baddie_2'].orientation == 4:
+                action_dict['baddie_2']['move'] = 2
+                action_dict['baddie_6']['move'] = 2
+                action_dict['baddie_9']['move'] = 3
             else:
-                action_dict['baddie_156']['move'] = 4
-                action_dict['baddie_162']['move'] = 4
-                action_dict['baddie_328']['move'] = 1
+                action_dict['baddie_2']['move'] = 4
+                action_dict['baddie_6']['move'] = 4
+                action_dict['baddie_9']['move'] = 1
         if self.step_count % 14 == 0:
-            action_dict['baddie_206']['move'] = 3
-            action_dict['baddie_222']['move'] = 1
+            action_dict['baddie_7']['move'] = 3
+            action_dict['baddie_8']['move'] = 1
         elif self.step_count % 14 == 3:
-            action_dict['baddie_206']['move'] = 2
-            action_dict['baddie_222']['move'] = 2
+            action_dict['baddie_7']['move'] = 2
+            action_dict['baddie_8']['move'] = 2
         elif self.step_count % 14 == 7:
-            action_dict['baddie_206']['move'] = 1
-            action_dict['baddie_222']['move'] = 3
+            action_dict['baddie_7']['move'] = 1
+            action_dict['baddie_8']['move'] = 3
         elif self.step_count % 14 == 9:
-            action_dict['baddie_206']['move'] = 4
-            action_dict['baddie_222']['move'] = 4
+            action_dict['baddie_7']['move'] = 4
+            action_dict['baddie_8']['move'] = 4
         elif self.step_count % 14 == 11:
-            action_dict['baddie_206']['move'] = 1
-            action_dict['baddie_222']['move'] = 3
+            action_dict['baddie_7']['move'] = 1
+            action_dict['baddie_8']['move'] = 3
         elif self.step_count % 14 == 12:
-            action_dict['baddie_206']['move'] = 4
-            action_dict['baddie_222']['move'] = 4
+            action_dict['baddie_7']['move'] = 4
+            action_dict['baddie_8']['move'] = 4
 
         # Now move the baddies and compute overlaps with pacman
         for agent_id, action in action_dict.items():

--- a/abmarl/sim/gridworld/base.py
+++ b/abmarl/sim/gridworld/base.py
@@ -127,17 +127,22 @@ class GridWorldSimulation(AgentBasedSimulation, ABC):
             agents = extra_agents
         else:
             agents = {}
-        n = 0
+        ndx = {}
         rows = array.shape[0]
         cols = array.shape[1]
         for r in range(rows):
             for c in range(cols):
                 char = array[r, c]
                 if char in object_registry:
+                    try:
+                        n = ndx[char]
+                    except KeyError:
+                        ndx[char] = 0
+                        n = 0
                     agent = object_registry[char](n)
                     agent.initial_position = np.array([r, c])
                     agents[agent.id] = agent
-                    n += 1
+                    ndx[char] += 1
 
         return cls._build_sim(rows, cols, agents=agents, **kwargs)
 
@@ -175,7 +180,7 @@ class GridWorldSimulation(AgentBasedSimulation, ABC):
             agents = extra_agents
         else:
             agents = {}
-        n = 0
+        ndx = {}
         with open(file_name, 'r') as fp:
             lines = fp.read().splitlines()
             cols = len(lines[0].split(' '))
@@ -185,10 +190,15 @@ class GridWorldSimulation(AgentBasedSimulation, ABC):
                 assert len(chars) == cols, f"Mismatched number of columns per row in {file_name}"
                 for col, char in enumerate(chars):
                     if char in object_registry:
+                        try:
+                            n = ndx[char]
+                        except KeyError:
+                            ndx[char] = 0
+                            n = 0
                         agent = object_registry[char](n)
                         agent.initial_position = np.array([row, col])
                         agents[agent.id] = agent
-                        n += 1
+                        ndx[char] += 1
 
         return cls._build_sim(rows, cols, agents=agents, **kwargs)
 

--- a/examples/rllib_pacman.py
+++ b/examples/rllib_pacman.py
@@ -60,8 +60,8 @@ policies = {
     ),
     'baddie': (
         None,
-        sim.sim.agents['baddie_157'].observation_space,
-        sim.sim.agents['baddie_157'].action_space, {}
+        sim.sim.agents['baddie_0'].observation_space,
+        sim.sim.agents['baddie_0'].action_space, {}
     ),
 }
 

--- a/examples/rllib_traffic_corridor_2_teams.py
+++ b/examples/rllib_traffic_corridor_2_teams.py
@@ -54,10 +54,10 @@ sim = MultiAgentWrapper(
             dones={"TargetAgentDone"},
             observers={'PositionCenteredEncodingObserver'},
             target_mapping={
-                'red4': 'red_target',
-                'red11': 'red_target',
+                'red0': 'red_target',
+                'red1': 'red_target',
                 'green0': 'green_target',
-                'green7': 'green_target',
+                'green1': 'green_target',
             }
         ),
         randomize_action_input=True,
@@ -71,8 +71,8 @@ register_env(sim_name, lambda sim_config: sim)
 policies = {
     'red': (
         None,
-        sim.sim.agents['red4'].observation_space,
-        sim.sim.agents['red4'].action_space,
+        sim.sim.agents['red0'].observation_space,
+        sim.sim.agents['red0'].action_space,
         {}
     ),
     'green': (

--- a/tests/sim/gridworld/test_base.py
+++ b/tests/sim/gridworld/test_base.py
@@ -211,14 +211,14 @@ def test_build_sim_from_array():
     sim.reset()
     assert 'A-class-barrier0' in sim.grid[0, 0]
     assert sim.grid[0, 1] == {}
-    assert 'B-class-barrier1' in sim.grid[0, 2]
+    assert 'B-class-barrier0' in sim.grid[0, 2]
     assert sim.grid[0, 3] == {}
     assert sim.grid[0, 4] == {}
-    assert 'B-class-barrier2' in sim.grid[1, 0]
+    assert 'B-class-barrier1' in sim.grid[1, 0]
     assert sim.grid[1, 1] == {}
     assert sim.grid[1, 2] == {}
-    assert 'C-class-barrier3' in sim.grid[1, 3]
-    assert 'A-class-barrier4' in sim.grid[1, 4]
+    assert 'C-class-barrier0' in sim.grid[1, 3]
+    assert 'A-class-barrier1' in sim.grid[1, 4]
 
     assert len(sim.agents) == 5
     assert sim.agents['A-class-barrier0'].encoding == 1
@@ -226,24 +226,24 @@ def test_build_sim_from_array():
         sim.agents['A-class-barrier0'].initial_position,
         np.array([0, 0])
     )
+    assert sim.agents['B-class-barrier0'].encoding == 2
+    np.testing.assert_array_equal(
+        sim.agents['B-class-barrier0'].initial_position,
+        np.array([0, 2])
+    )
     assert sim.agents['B-class-barrier1'].encoding == 2
     np.testing.assert_array_equal(
         sim.agents['B-class-barrier1'].initial_position,
-        np.array([0, 2])
-    )
-    assert sim.agents['B-class-barrier2'].encoding == 2
-    np.testing.assert_array_equal(
-        sim.agents['B-class-barrier2'].initial_position,
         np.array([1, 0])
     )
-    assert sim.agents['C-class-barrier3'].encoding == 3
+    assert sim.agents['C-class-barrier0'].encoding == 3
     np.testing.assert_array_equal(
-        sim.agents['C-class-barrier3'].initial_position,
+        sim.agents['C-class-barrier0'].initial_position,
         np.array([1, 3])
     )
-    assert sim.agents['A-class-barrier4'].encoding == 1
+    assert sim.agents['A-class-barrier1'].encoding == 1
     np.testing.assert_array_equal(
-        sim.agents['A-class-barrier4'].initial_position,
+        sim.agents['A-class-barrier1'].initial_position,
         np.array([1, 4])
     )
 
@@ -256,35 +256,35 @@ def test_build_sim_from_array():
     sim.reset()
     assert 'A-class-barrier0' in sim.grid[0, 0]
     assert sim.grid[0, 1] == {}
-    assert 'B-class-barrier1' in sim.grid[0, 2]
+    assert 'B-class-barrier0' in sim.grid[0, 2]
     assert sim.grid[0, 3] == {}
     assert sim.grid[0, 4] == {}
-    assert 'B-class-barrier2' in sim.grid[1, 0]
+    assert 'B-class-barrier1' in sim.grid[1, 0]
     assert sim.grid[1, 1] == {}
     assert sim.grid[1, 2] == {}
     assert sim.grid[1, 3] == {}
-    assert 'A-class-barrier3' in sim.grid[1, 4]
+    assert 'A-class-barrier1' in sim.grid[1, 4]
 
     assert len(sim.agents) == 4
-    assert 'C-class-barrier3' not in sim.agents
+    assert 'C-class-barrier0' not in sim.agents
     assert sim.agents['A-class-barrier0'].encoding == 1
     np.testing.assert_array_equal(
         sim.agents['A-class-barrier0'].initial_position,
         np.array([0, 0])
     )
+    assert sim.agents['B-class-barrier0'].encoding == 2
+    np.testing.assert_array_equal(
+        sim.agents['B-class-barrier0'].initial_position,
+        np.array([0, 2])
+    )
     assert sim.agents['B-class-barrier1'].encoding == 2
     np.testing.assert_array_equal(
         sim.agents['B-class-barrier1'].initial_position,
-        np.array([0, 2])
-    )
-    assert sim.agents['B-class-barrier2'].encoding == 2
-    np.testing.assert_array_equal(
-        sim.agents['B-class-barrier2'].initial_position,
         np.array([1, 0])
     )
-    assert sim.agents['A-class-barrier3'].encoding == 1
+    assert sim.agents['A-class-barrier1'].encoding == 1
     np.testing.assert_array_equal(
-        sim.agents['A-class-barrier3'].initial_position,
+        sim.agents['A-class-barrier1'].initial_position,
         np.array([1, 4])
     )
 
@@ -324,13 +324,13 @@ def test_build_sim_from_array_with_extra_agents():
             encoding=3,
         ),
     }
-    # B-class-barrier2 exists in the array, so the builder should not use the one
+    # B-class-barrier1 exists in the array, so the builder should not use the one
     # in extra_agents
     # extra_agent0 and 1 will exist because they can overlap
     # extra_agent2 will exist because it occupies an empty space
     extra_agents = {
-        'B-class-barrier2': GridWorldAgent(
-            id='B-class-barrier2',
+        'B-class-barrier1': GridWorldAgent(
+            id='B-class-barrier1',
             encoding=4,
             initial_position=np.array([1, 0])
         ),
@@ -361,15 +361,15 @@ def test_build_sim_from_array_with_extra_agents():
     assert 'extra_agent0' in sim.grid[0, 0]
     assert 'extra_agent1' in sim.grid[0, 0]
     assert sim.grid[0, 1] == {}
-    assert 'B-class-barrier1' in sim.grid[0, 2]
+    assert 'B-class-barrier0' in sim.grid[0, 2]
     assert sim.grid[0, 3] == {}
     assert next(iter(sim.grid[0, 4].values())) == extra_agents['extra_agent2']
-    assert 'B-class-barrier2' in sim.grid[1, 0]
+    assert 'B-class-barrier1' in sim.grid[1, 0]
     assert next(iter(sim.grid[1, 0].values())).encoding == 2
     assert sim.grid[1, 1] == {}
     assert sim.grid[1, 2] == {}
-    assert 'C-class-barrier3' in sim.grid[1, 3]
-    assert 'A-class-barrier4' in sim.grid[1, 4]
+    assert 'C-class-barrier0' in sim.grid[1, 3]
+    assert 'A-class-barrier1' in sim.grid[1, 4]
 
     assert len(sim.agents) == 8
     assert sim.agents['A-class-barrier0'].encoding == 1
@@ -377,24 +377,24 @@ def test_build_sim_from_array_with_extra_agents():
         sim.agents['A-class-barrier0'].initial_position,
         np.array([0, 0])
     )
+    assert sim.agents['B-class-barrier0'].encoding == 2
+    np.testing.assert_array_equal(
+        sim.agents['B-class-barrier0'].initial_position,
+        np.array([0, 2])
+    )
     assert sim.agents['B-class-barrier1'].encoding == 2
     np.testing.assert_array_equal(
         sim.agents['B-class-barrier1'].initial_position,
-        np.array([0, 2])
-    )
-    assert sim.agents['B-class-barrier2'].encoding == 2
-    np.testing.assert_array_equal(
-        sim.agents['B-class-barrier2'].initial_position,
         np.array([1, 0])
     )
-    assert sim.agents['C-class-barrier3'].encoding == 3
+    assert sim.agents['C-class-barrier0'].encoding == 3
     np.testing.assert_array_equal(
-        sim.agents['C-class-barrier3'].initial_position,
+        sim.agents['C-class-barrier0'].initial_position,
         np.array([1, 3])
     )
-    assert sim.agents['A-class-barrier4'].encoding == 1
+    assert sim.agents['A-class-barrier1'].encoding == 1
     np.testing.assert_array_equal(
-        sim.agents['A-class-barrier4'].initial_position,
+        sim.agents['A-class-barrier1'].initial_position,
         np.array([1, 4])
     )
     assert sim.agents['extra_agent0'].encoding == 5
@@ -459,14 +459,14 @@ def test_build_sim_from_file():
     sim.reset()
     assert 'A-class-barrier0' in sim.grid[0, 0]
     assert sim.grid[0, 1] == {}
-    assert 'B-class-barrier1' in sim.grid[0, 2]
+    assert 'B-class-barrier0' in sim.grid[0, 2]
     assert sim.grid[0, 3] == {}
     assert sim.grid[0, 4] == {}
-    assert 'B-class-barrier2' in sim.grid[1, 0]
+    assert 'B-class-barrier1' in sim.grid[1, 0]
     assert sim.grid[1, 1] == {}
     assert sim.grid[1, 2] == {}
-    assert 'C-class-barrier3' in sim.grid[1, 3]
-    assert 'A-class-barrier4' in sim.grid[1, 4]
+    assert 'C-class-barrier0' in sim.grid[1, 3]
+    assert 'A-class-barrier1' in sim.grid[1, 4]
 
     assert len(sim.agents) == 5
     assert sim.agents['A-class-barrier0'].encoding == 1
@@ -474,24 +474,24 @@ def test_build_sim_from_file():
         sim.agents['A-class-barrier0'].initial_position,
         np.array([0, 0])
     )
+    assert sim.agents['B-class-barrier0'].encoding == 2
+    np.testing.assert_array_equal(
+        sim.agents['B-class-barrier0'].initial_position,
+        np.array([0, 2])
+    )
     assert sim.agents['B-class-barrier1'].encoding == 2
     np.testing.assert_array_equal(
         sim.agents['B-class-barrier1'].initial_position,
-        np.array([0, 2])
-    )
-    assert sim.agents['B-class-barrier2'].encoding == 2
-    np.testing.assert_array_equal(
-        sim.agents['B-class-barrier2'].initial_position,
         np.array([1, 0])
     )
-    assert sim.agents['C-class-barrier3'].encoding == 3
+    assert sim.agents['C-class-barrier0'].encoding == 3
     np.testing.assert_array_equal(
-        sim.agents['C-class-barrier3'].initial_position,
+        sim.agents['C-class-barrier0'].initial_position,
         np.array([1, 3])
     )
-    assert sim.agents['A-class-barrier4'].encoding == 1
+    assert sim.agents['A-class-barrier1'].encoding == 1
     np.testing.assert_array_equal(
-        sim.agents['A-class-barrier4'].initial_position,
+        sim.agents['A-class-barrier1'].initial_position,
         np.array([1, 4])
     )
 
@@ -504,35 +504,35 @@ def test_build_sim_from_file():
     sim.reset()
     assert 'A-class-barrier0' in sim.grid[0, 0]
     assert sim.grid[0, 1] == {}
-    assert 'B-class-barrier1' in sim.grid[0, 2]
+    assert 'B-class-barrier0' in sim.grid[0, 2]
     assert sim.grid[0, 3] == {}
     assert sim.grid[0, 4] == {}
-    assert 'B-class-barrier2' in sim.grid[1, 0]
+    assert 'B-class-barrier1' in sim.grid[1, 0]
     assert sim.grid[1, 1] == {}
     assert sim.grid[1, 2] == {}
     assert sim.grid[1, 3] == {}
-    assert 'A-class-barrier3' in sim.grid[1, 4]
+    assert 'A-class-barrier1' in sim.grid[1, 4]
 
     assert len(sim.agents) == 4
-    assert 'C-class-barrier3' not in sim.agents
+    assert 'C-class-barrier0' not in sim.agents
     assert sim.agents['A-class-barrier0'].encoding == 1
     np.testing.assert_array_equal(
         sim.agents['A-class-barrier0'].initial_position,
         np.array([0, 0])
     )
+    assert sim.agents['B-class-barrier0'].encoding == 2
+    np.testing.assert_array_equal(
+        sim.agents['B-class-barrier0'].initial_position,
+        np.array([0, 2])
+    )
     assert sim.agents['B-class-barrier1'].encoding == 2
     np.testing.assert_array_equal(
         sim.agents['B-class-barrier1'].initial_position,
-        np.array([0, 2])
-    )
-    assert sim.agents['B-class-barrier2'].encoding == 2
-    np.testing.assert_array_equal(
-        sim.agents['B-class-barrier2'].initial_position,
         np.array([1, 0])
     )
-    assert sim.agents['A-class-barrier3'].encoding == 1
+    assert sim.agents['A-class-barrier1'].encoding == 1
     np.testing.assert_array_equal(
-        sim.agents['A-class-barrier3'].initial_position,
+        sim.agents['A-class-barrier1'].initial_position,
         np.array([1, 4])
     )
 
@@ -572,13 +572,13 @@ def test_build_sim_from_file_with_extra_agents():
             encoding=3,
         ),
     }
-    # B-class-barrier2 exists in the file, so the builder should not use the one
+    # B-class-barrier1 exists in the file, so the builder should not use the one
     # in extra_agents
     # extra_agent0 and 1 will exist because they can overlap
     # extra_agent2 will exist because it occupies an empty space
     extra_agents = {
-        'B-class-barrier2': GridWorldAgent(
-            id='B-class-barrier2',
+        'B-class-barrier1': GridWorldAgent(
+            id='B-class-barrier1',
             encoding=4,
             initial_position=np.array([1, 0])
         ),
@@ -609,15 +609,15 @@ def test_build_sim_from_file_with_extra_agents():
     assert 'extra_agent0' in sim.grid[0, 0]
     assert 'extra_agent1' in sim.grid[0, 0]
     assert sim.grid[0, 1] == {}
-    assert 'B-class-barrier1' in sim.grid[0, 2]
+    assert 'B-class-barrier0' in sim.grid[0, 2]
     assert sim.grid[0, 3] == {}
     assert next(iter(sim.grid[0, 4].values())) == extra_agents['extra_agent2']
-    assert 'B-class-barrier2' in sim.grid[1, 0]
+    assert 'B-class-barrier1' in sim.grid[1, 0]
     assert next(iter(sim.grid[1, 0].values())).encoding == 2
     assert sim.grid[1, 1] == {}
     assert sim.grid[1, 2] == {}
-    assert 'C-class-barrier3' in sim.grid[1, 3]
-    assert 'A-class-barrier4' in sim.grid[1, 4]
+    assert 'C-class-barrier0' in sim.grid[1, 3]
+    assert 'A-class-barrier1' in sim.grid[1, 4]
 
     assert len(sim.agents) == 8
     assert sim.agents['A-class-barrier0'].encoding == 1
@@ -625,24 +625,24 @@ def test_build_sim_from_file_with_extra_agents():
         sim.agents['A-class-barrier0'].initial_position,
         np.array([0, 0])
     )
+    assert sim.agents['B-class-barrier0'].encoding == 2
+    np.testing.assert_array_equal(
+        sim.agents['B-class-barrier0'].initial_position,
+        np.array([0, 2])
+    )
     assert sim.agents['B-class-barrier1'].encoding == 2
     np.testing.assert_array_equal(
         sim.agents['B-class-barrier1'].initial_position,
-        np.array([0, 2])
-    )
-    assert sim.agents['B-class-barrier2'].encoding == 2
-    np.testing.assert_array_equal(
-        sim.agents['B-class-barrier2'].initial_position,
         np.array([1, 0])
     )
-    assert sim.agents['C-class-barrier3'].encoding == 3
+    assert sim.agents['C-class-barrier0'].encoding == 3
     np.testing.assert_array_equal(
-        sim.agents['C-class-barrier3'].initial_position,
+        sim.agents['C-class-barrier0'].initial_position,
         np.array([1, 3])
     )
-    assert sim.agents['A-class-barrier4'].encoding == 1
+    assert sim.agents['A-class-barrier1'].encoding == 1
     np.testing.assert_array_equal(
-        sim.agents['A-class-barrier4'].initial_position,
+        sim.agents['A-class-barrier1'].initial_position,
         np.array([1, 4])
     )
     assert sim.agents['extra_agent0'].encoding == 5


### PR DESCRIPTION
Building from file and array not indexes the agent ids based on the characters in the object registry instead of globally. So we will see things like "{red0, red1, green0, green1}" instead of "red4, red11, green0, green7".

Resolves #476